### PR TITLE
feat: simplify backend routing with Railway internal networking

### DIFF
--- a/apps/agent/app.py
+++ b/apps/agent/app.py
@@ -9,7 +9,9 @@ Future features will include content generation, task analysis, and meeting summ
 import logging
 from contextlib import asynccontextmanager
 
-import uvicorn
+import asyncio
+from hypercorn.config import Config as HypercornConfig
+from hypercorn.asyncio import serve
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -113,14 +115,26 @@ async def api_info():
 
 
 def main():
-    """Run the server."""
-    uvicorn.run(
-        "app:app",
-        host=config.HOST,
-        port=config.PORT,
-        reload=config.DEBUG,
-        log_level="info",
-    )
+    """Run the server with Hypercorn for dual-stack binding."""
+    # Create Hypercorn config
+    hypercorn_config = HypercornConfig()
+    
+    # Dual-stack binding for Railway: IPv4 for public + healthcheck, IPv6 for private networking
+    hypercorn_config.bind = [
+        f"0.0.0.0:{config.PORT}",  # IPv4 for public access and healthcheck
+        f"[::]:{config.PORT}"       # IPv6 for Railway private networking
+    ]
+    
+    hypercorn_config.loglevel = "info"
+    
+    # Log configuration
+    logger.info(f"🌐 Hypercorn dual-stack binding:")
+    logger.info(f"   - IPv4: 0.0.0.0:{config.PORT}")
+    logger.info(f"   - IPv6: [::]:{config.PORT}")
+    logger.info(f"🐛 Debug mode: {config.DEBUG}")
+    
+    # Run server
+    asyncio.run(serve(app, hypercorn_config))
 
 
 if __name__ == "__main__":

--- a/apps/agent/app.py
+++ b/apps/agent/app.py
@@ -39,7 +39,7 @@ async def lifespan(app: FastAPI):
         logger.error(f"❌ Environment validation failed: {e}")
         raise
 
-    logger.info(f"🌐 Server configured for host: {config.HOST}:{config.PORT}")
+    logger.info(f"🌐 Server configured for port: {config.PORT}")
     logger.info(f"🔧 Debug mode: {config.DEBUG}")
 
     yield

--- a/apps/agent/app.py
+++ b/apps/agent/app.py
@@ -119,18 +119,13 @@ def main():
     # Create Hypercorn config
     hypercorn_config = HypercornConfig()
     
-    # Dual-stack binding for Railway: IPv4 for public + healthcheck, IPv6 for private networking
-    hypercorn_config.bind = [
-        f"0.0.0.0:{config.PORT}",  # IPv4 for public access and healthcheck
-        f"[::]:{config.PORT}"       # IPv6 for Railway private networking
-    ]
+    # IPv6 binding that accepts both IPv4 and IPv6 connections
+    hypercorn_config.bind = [f"[::]:{config.PORT}"]
     
     hypercorn_config.loglevel = "info"
     
     # Log configuration
-    logger.info(f"🌐 Hypercorn dual-stack binding:")
-    logger.info(f"   - IPv4: 0.0.0.0:{config.PORT}")
-    logger.info(f"   - IPv6: [::]:{config.PORT}")
+    logger.info(f"🌐 Hypercorn IPv6 binding: [::]:{config.PORT}")
     logger.info(f"🐛 Debug mode: {config.DEBUG}")
     
     # Run server

--- a/apps/agent/railway.toml
+++ b/apps/agent/railway.toml
@@ -4,10 +4,10 @@ dockerfilePath = "apps/agent/Dockerfile"
 watchPatterns = ["apps/agent/**"]
 
 [deploy]
-# healthcheckPath = "/api/v1/health"
-# healthcheckTimeout = 30
-# restartPolicyType = "always"
-# restartPolicyMaxRetries = 3
+healthcheckPath = "/api/v1/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3
 
 [env]
 # These will be set in Railway dashboard

--- a/apps/agent/railway.toml
+++ b/apps/agent/railway.toml
@@ -4,10 +4,10 @@ dockerfilePath = "apps/agent/Dockerfile"
 watchPatterns = ["apps/agent/**"]
 
 [deploy]
-healthcheckPath = "/api/v1/health"
-healthcheckTimeout = 30
-restartPolicyType = "on_failure"
-restartPolicyMaxRetries = 3
+# healthcheckPath = "/api/v1/health"
+# healthcheckTimeout = 30
+# restartPolicyType = "always"
+# restartPolicyMaxRetries = 3
 
 [env]
 # These will be set in Railway dashboard

--- a/apps/agent/requirements.txt
+++ b/apps/agent/requirements.txt
@@ -1,6 +1,6 @@
 # Web framework
 fastapi==0.115.6
-uvicorn[standard]==0.32.1
+hypercorn==0.17.3
 
 # Core dependencies
 python-dotenv==1.0.1

--- a/apps/agent/utils/config.py
+++ b/apps/agent/utils/config.py
@@ -16,7 +16,7 @@ class Config:
     """Configuration class for the Agent server."""
 
     # Server config
-    HOST: str = os.getenv("HOST", "0.0.0.0")
+    HOST: str = os.getenv("HOST", "::")
     PORT: int = int(os.getenv("PORT", "8000"))
     DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"
 

--- a/apps/agent/utils/config.py
+++ b/apps/agent/utils/config.py
@@ -15,9 +15,8 @@ load_dotenv()
 class Config:
     """Configuration class for the Agent server."""
 
-    # Server config - use 0.0.0.0 for Railway compatibility
-    # Railway's private networking will still work with this binding
-    HOST: str = os.getenv("HOST", "0.0.0.0")
+    # Server config - Hypercorn handles dual-stack binding
+    # HOST not needed with Hypercorn's explicit bind configuration
     PORT: int = int(os.getenv("PORT", "8000"))
     DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"
 

--- a/apps/agent/utils/config.py
+++ b/apps/agent/utils/config.py
@@ -15,8 +15,9 @@ load_dotenv()
 class Config:
     """Configuration class for the Agent server."""
 
-    # Server config
-    HOST: str = os.getenv("HOST", "::")
+    # Server config - use 0.0.0.0 for Railway compatibility
+    # Railway's private networking will still work with this binding
+    HOST: str = os.getenv("HOST", "0.0.0.0")
     PORT: int = int(os.getenv("PORT", "8000"))
     DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -18,9 +18,11 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY apps/web ./
 
-# Accept build argument for environment
+# Accept build arguments
 ARG ENVIRONMENT
+ARG BACKEND_URL
 ENV ENVIRONMENT=${ENVIRONMENT}
+ENV BACKEND_URL=${BACKEND_URL}
 
 RUN npm run build
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,46 +4,15 @@ const nextConfig: NextConfig = {
   // Enable standalone mode for Docker
   output: 'standalone',
   
-  env: {
-    NEXT_PUBLIC_ENVIRONMENT: process.env.ENVIRONMENT,
-  },
-  
   async rewrites() {
-    // Determine backend URL based on environment
-    let backendUrl = process.env.BACKEND_URL;
+    // Simple backend URL determination
+    const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
     
-    const railwayDomain = process.env.RAILWAY_PUBLIC_DOMAIN || '';
-    const nodeEnv = process.env.NODE_ENV;
-    
-    console.log('🔧 NEXT.CONFIG Environment Check:', {
-      BACKEND_URL: backendUrl,
-      NODE_ENV: nodeEnv,
-      RAILWAY_PUBLIC_DOMAIN: railwayDomain,
-      VERCEL_URL: process.env.VERCEL_URL,
-      allRailwayVars: Object.keys(process.env).filter(key => key.includes('RAILWAY')).reduce((obj, key) => {
-        obj[key] = process.env[key];
-        return obj;
-      }, {} as Record<string, string | undefined>)
+    console.log('🔧 Backend URL:', {
+      BACKEND_URL: process.env.BACKEND_URL,
+      resolvedUrl: backendUrl,
+      NODE_ENV: process.env.NODE_ENV
     });
-    
-    if (!backendUrl) {
-      if (nodeEnv === 'production') {
-        // Check environment variable we set manually
-        const isStaging = process.env.ENVIRONMENT === 'staging';
-        backendUrl = isStaging 
-          ? 'https://staging.agent.evanm.xyz'
-          : 'https://agent.evanm.xyz';
-          
-        console.log('🎯 Backend URL Decision:', { 
-          ENVIRONMENT: process.env.ENVIRONMENT,
-          hostname: process.env.RAILWAY_PUBLIC_DOMAIN,
-          isStaging, 
-          backendUrl 
-        });
-      } else {
-        backendUrl = 'http://localhost:8000';
-      }
-    }
         
     return [
       {

--- a/apps/web/src/utils/environment.ts
+++ b/apps/web/src/utils/environment.ts
@@ -1,43 +1,33 @@
 export function getEnvironmentInfo() {
   if (typeof window === 'undefined') {
-    // Server-side - check environment variable
-    const isStaging = process.env.ENVIRONMENT === 'staging';
-    
-    console.log('🖥️ SERVER Environment Detection:', {
-      ENVIRONMENT: process.env.ENVIRONMENT,
-      isStaging,
-      NODE_ENV: process.env.NODE_ENV
-    });
-    
+    // Server-side - for display purposes only
     return {
-      isStaging,
+      isStaging: false,
       isLocal: false,
-      agentDomain: isStaging ? 'staging.agent.evanm.xyz' : 'agent.evanm.xyz'
+      agentDomain: 'agent.evanm.xyz' // Default display
     };
   }
   
-  // Client-side
+  // Client-side - determine display domain from hostname
   const hostname = window.location.hostname;
-  const isLocal = hostname === 'localhost' || hostname === '127.0.0.1' || hostname.includes('localhost');
+  const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
+  const isStaging = hostname.includes('staging');
+  const isPR = hostname.includes('railway.app') && !isLocal;
   
-  // Check for staging using environment variable or hostname patterns
-  const environment = process.env.NEXT_PUBLIC_ENVIRONMENT || '';
-  const isStaging = hostname.includes('staging') || environment === 'staging';
-  
-  console.log('🌐 CLIENT Environment Detection:', {
-    hostname,
-    environment,
-    isLocal,
-    isStaging,
-    allPublicVars: Object.keys(process.env).filter(key => key.startsWith('NEXT_PUBLIC')).reduce((obj, key) => {
-      obj[key] = process.env[key];
-      return obj;
-    }, {} as Record<string, string | undefined>)
-  });
+  let displayDomain: string;
+  if (isLocal) {
+    displayDomain = 'localhost:8000';
+  } else if (isStaging) {
+    displayDomain = 'staging.agent.evanm.xyz';
+  } else if (isPR) {
+    displayDomain = 'agent (internal)';
+  } else {
+    displayDomain = 'agent.evanm.xyz';
+  }
   
   return {
     isStaging,
     isLocal,
-    agentDomain: isLocal ? 'localhost:8000' : (isStaging ? 'staging.agent.evanm.xyz' : 'agent.evanm.xyz')
+    agentDomain: displayDomain
   };
 }


### PR DESCRIPTION
- Remove complex environment detection logic from next.config.ts
- Use single BACKEND_URL environment variable (http://agent:8000)
- Simplify client-side display logic for different environments
- Improve Railway service-to-service communication reliability
- Clean up logging for better debugging

🤖 Generated with [Claude Code](https://claude.ai/code)