### PR TITLE
Web chat UI backed by local Claude agent (claude-bridge)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "react-dom": "19.1.0",
     "react-draggable": "^4.5.0",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "swr": "^2.4.0"
   },
   "devDependencies": {

--- a/apps/web/public/chat.webmanifest
+++ b/apps/web/public/chat.webmanifest
@@ -5,8 +5,8 @@
   "start_url": "/chat",
   "scope": "/chat",
   "display": "standalone",
-  "background_color": "#262624",
-  "theme_color": "#262624",
+  "background_color": "#F7F6F4",
+  "theme_color": "#1C2B4A",
   "icons": [
     { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }

--- a/apps/web/public/chat.webmanifest
+++ b/apps/web/public/chat.webmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "Claude Chat",
+  "short_name": "Claude",
+  "description": "Personal Claude agent with local memory",
+  "start_url": "/chat",
+  "scope": "/chat",
+  "display": "standalone",
+  "background_color": "#262624",
+  "theme_color": "#262624",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
+  ]
+}

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -28,6 +28,39 @@ self.addEventListener('activate', (event) => {
   self.clients.claim();
 });
 
+// Push: show notification + set app badge when a Claude run finishes.
+self.addEventListener('push', (event) => {
+  let data = {};
+  try { data = event.data ? event.data.json() : {}; } catch (e) { /* noop */ }
+  const title = data.title || 'Claude';
+  const options = {
+    body: data.body || '',
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    tag: data.conversationId || 'claude',
+    data: { conversationId: data.conversationId },
+  };
+  event.waitUntil((async () => {
+    await self.registration.showNotification(title, options);
+    if (self.navigator && self.navigator.setAppBadge) {
+      try { await self.navigator.setAppBadge(data.badge || 1); } catch (e) { /* noop */ }
+    }
+  })());
+});
+
+// Tap a notification: focus the chat (and clear the badge).
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  event.waitUntil((async () => {
+    if (self.navigator && self.navigator.clearAppBadge) {
+      try { await self.navigator.clearAppBadge(); } catch (e) { /* noop */ }
+    }
+    const wins = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const c of wins) { if (c.url.includes('/chat')) return c.focus(); }
+    return self.clients.openWindow('/chat');
+  })());
+});
+
 // Fetch: network-first for API, stale-while-revalidate for assets
 self.addEventListener('fetch', (event) => {
   const { request } = event;

--- a/apps/web/src/app/api/bridge/[...path]/route.ts
+++ b/apps/web/src/app/api/bridge/[...path]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateApiAuth } from '@/server/dashboard/auth';
+
+// Server-side proxy to the local claude-bridge. Keeps BRIDGE_TOKEN off the client.
+// Forwards CRUD (JSON) and /chat (SSE) transparently by streaming the upstream body.
+const BRIDGE_URL = process.env.BRIDGE_URL ?? 'http://127.0.0.1:8787';
+const BRIDGE_TOKEN = process.env.BRIDGE_TOKEN ?? '';
+
+async function proxy(req: NextRequest, path: string[]) {
+  if (!validateApiAuth(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const target = `${BRIDGE_URL}/${path.join('/')}${req.nextUrl.search}`;
+  const isBodyless = req.method === 'GET' || req.method === 'HEAD';
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: req.method,
+      headers: {
+        Authorization: `Bearer ${BRIDGE_TOKEN}`,
+        'content-type': req.headers.get('content-type') ?? 'application/json',
+      },
+      body: isBodyless ? undefined : await req.text(),
+      // @ts-expect-error - Node fetch needs duplex for request bodies
+      duplex: 'half',
+    });
+  } catch {
+    return NextResponse.json(
+      { error: 'bridge unreachable', hint: 'Is claude-bridge running / Funnel up?' },
+      { status: 502 },
+    );
+  }
+
+  // Stream the upstream body straight through (works for JSON and text/event-stream).
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      'content-type': upstream.headers.get('content-type') ?? 'application/json',
+      'cache-control': 'no-cache',
+    },
+  });
+}
+
+export async function GET(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
+  return proxy(req, (await ctx.params).path);
+}
+export async function POST(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
+  return proxy(req, (await ctx.params).path);
+}

--- a/apps/web/src/app/api/bridge/[...path]/route.ts
+++ b/apps/web/src/app/api/bridge/[...path]/route.ts
@@ -48,3 +48,6 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ path: strin
 export async function POST(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
   return proxy(req, (await ctx.params).path);
 }
+export async function DELETE(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
+  return proxy(req, (await ctx.params).path);
+}

--- a/apps/web/src/app/chat/chat.css
+++ b/apps/web/src/app/chat/chat.css
@@ -1,0 +1,92 @@
+:root {
+  --c-bg: #262624;
+  --c-side: #1c1b1a;
+  --c-panel: #30302e;
+  --c-border: #3a3937;
+  --c-text: #ece9e3;
+  --c-dim: #9c9893;
+  --c-accent: #d97757;
+  --c-accent-dim: #b85f43;
+}
+
+.chat-shell {
+  position: fixed; inset: 0;
+  display: grid; grid-template-columns: 272px 1fr;
+  background: var(--c-bg); color: var(--c-text);
+  font: 14px/1.55 ui-sans-serif, system-ui, -apple-system, sans-serif;
+}
+
+/* Sidebar */
+.chat-sidebar { background: var(--c-side); border-right: 1px solid var(--c-border); display: flex; flex-direction: column; overflow: hidden; }
+.chat-profile { display: flex; align-items: center; gap: 8px; padding: 14px 14px 10px; color: var(--c-dim); }
+.chat-profile select { flex: 1; background: var(--c-panel); color: var(--c-text); border: 1px solid var(--c-border); border-radius: 8px; padding: 6px 8px; font-size: 13px; }
+.chat-projects { flex: 1; overflow-y: auto; padding: 6px 8px 16px; }
+.chat-project { margin-bottom: 14px; }
+.chat-project-head { display: flex; align-items: center; justify-content: space-between; color: var(--c-dim); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; padding: 4px 8px; }
+.chat-project-head span { display: inline-flex; align-items: center; gap: 6px; }
+.chat-project-head em { color: var(--c-accent); font-style: normal; font-size: 10px; }
+.chat-project-head button { color: var(--c-dim); padding: 2px; border-radius: 6px; }
+.chat-project-head button:hover { color: var(--c-text); background: var(--c-panel); }
+.chat-conv { display: block; width: 100%; text-align: left; padding: 7px 10px; border-radius: 8px; color: var(--c-text); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.chat-conv:hover { background: var(--c-panel); }
+.chat-conv-on { background: var(--c-panel); box-shadow: inset 2px 0 0 var(--c-accent); }
+
+/* Main */
+.chat-main { display: flex; flex-direction: column; overflow: hidden; }
+.chat-thread { flex: 1; overflow-y: auto; padding: 28px 0 24px; }
+.chat-empty { color: var(--c-dim); text-align: center; margin-top: 22vh; }
+.chat-msg { max-width: 760px; margin: 0 auto 22px; padding: 0 28px; }
+.chat-msg-user .chat-user-text { background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 14px; padding: 12px 16px; white-space: pre-wrap; }
+.chat-msg-assistant { color: var(--c-text); }
+.chat-tools { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
+.chat-tools span { font-size: 11px; color: var(--c-dim); background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 999px; padding: 2px 9px; }
+
+/* Composer */
+.chat-composer { border-top: 1px solid var(--c-border); background: var(--c-bg); padding: 12px 0 16px; }
+.chat-attachments, .chat-composer textarea, .chat-composer-bar { max-width: 760px; margin: 0 auto; padding: 0 28px; }
+.chat-attachments { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 8px; color: var(--c-dim); font-size: 12px; }
+.chat-composer textarea { display: block; width: 100%; box-sizing: border-box; background: var(--c-panel); color: var(--c-text); border: 1px solid var(--c-border); border-radius: 12px; padding: 12px 14px; resize: vertical; font: inherit; outline: none; }
+.chat-composer textarea:focus { border-color: var(--c-accent-dim); }
+.chat-composer-bar { display: flex; align-items: center; justify-content: space-between; margin-top: 8px; }
+.chat-composer-left { display: flex; align-items: center; gap: 10px; }
+.chat-composer-left button { color: var(--c-dim); padding: 6px; border-radius: 8px; }
+.chat-composer-left button:hover { color: var(--c-text); background: var(--c-panel); }
+.chat-composer-left select { background: var(--c-panel); color: var(--c-text); border: 1px solid var(--c-border); border-radius: 8px; padding: 5px 8px; font-size: 12px; }
+.chat-cwd { color: var(--c-dim); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 240px; }
+.chat-send { background: var(--c-accent); color: #fff; border-radius: 10px; padding: 9px 12px; display: inline-flex; }
+.chat-send:disabled { opacity: .45; }
+.chat-send:not(:disabled):hover { background: var(--c-accent-dim); }
+.chat-spin { animation: chat-spin 1s linear infinite; }
+@keyframes chat-spin { to { transform: rotate(360deg); } }
+
+/* Questions */
+.chat-questions { max-width: 760px; margin: 0 auto 22px; padding: 16px 28px; }
+.chat-questions-title { font-weight: 600; margin-bottom: 12px; }
+.chat-question { background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 12px; padding: 14px; margin-bottom: 12px; }
+.chat-question-label { margin-bottom: 10px; }
+.chat-question-chip { display: inline-block; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: var(--c-accent); border: 1px solid var(--c-accent-dim); border-radius: 6px; padding: 1px 6px; margin-right: 8px; }
+.chat-question-options { display: grid; gap: 8px; margin-bottom: 10px; }
+.chat-option { text-align: left; border: 1px solid var(--c-border); border-radius: 10px; padding: 9px 12px; background: var(--c-bg); display: flex; flex-direction: column; gap: 2px; }
+.chat-option:hover { border-color: var(--c-accent-dim); }
+.chat-option-on { border-color: var(--c-accent); box-shadow: inset 0 0 0 1px var(--c-accent); }
+.chat-option-label { font-weight: 600; font-size: 13px; }
+.chat-option-desc { color: var(--c-dim); font-size: 12px; }
+.chat-question-custom { width: 100%; box-sizing: border-box; background: var(--c-bg); color: var(--c-text); border: 1px solid var(--c-border); border-radius: 8px; padding: 8px 10px; font: inherit; }
+.chat-submit-answers { background: var(--c-accent); color: #fff; border-radius: 10px; padding: 9px 16px; font-weight: 600; }
+.chat-submit-answers:disabled { opacity: .45; }
+
+/* Markdown */
+.chat-prose > :first-child { margin-top: 0; }
+.chat-prose > :last-child { margin-bottom: 0; }
+.chat-prose p { margin: 0 0 12px; }
+.chat-prose h1, .chat-prose h2, .chat-prose h3 { margin: 18px 0 8px; line-height: 1.3; }
+.chat-prose ul { margin: 0 0 12px; padding-left: 22px; list-style: disc; }
+.chat-prose ol { margin: 0 0 12px; padding-left: 22px; list-style: decimal; }
+.chat-prose li { margin: 3px 0; }
+.chat-prose pre { background: var(--c-side); border: 1px solid var(--c-border); border-radius: 10px; padding: 12px 14px; overflow-x: auto; margin: 0 0 12px; }
+.chat-prose code { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 12.5px; }
+.chat-code-inline { background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 5px; padding: 1px 5px; }
+.chat-prose table { border-collapse: collapse; margin: 0 0 12px; width: 100%; }
+.chat-prose th, .chat-prose td { border: 1px solid var(--c-border); padding: 6px 10px; text-align: left; }
+.chat-prose blockquote { border-left: 3px solid var(--c-border); margin: 0 0 12px; padding-left: 12px; color: var(--c-dim); }
+.chat-prose a { color: var(--c-accent); text-decoration: underline; }

--- a/apps/web/src/app/chat/chat.css
+++ b/apps/web/src/app/chat/chat.css
@@ -25,7 +25,7 @@
 
 /* Working / queued status */
 .chat-status { max-width: 760px; margin: 0 auto 8px; padding: 0 28px; display: flex; align-items: center; gap: 7px; color: var(--c-dim); font-size: 12px; }
-.chat-newchat { display: flex; align-items: center; justify-content: center; gap: 7px; margin: 4px 12px 8px; padding: 9px 12px; background: var(--c-accent); color: #fff; border-radius: 10px; font-weight: 600; font-size: 13px; }
+.chat-newchat { display: flex; align-items: center; justify-content: center; gap: 7px; margin: 8px 0 0; padding: 9px 12px; background: var(--c-accent); color: #fff; border-radius: 10px; font-weight: 600; font-size: 13px; }
 .chat-newchat:hover:not(:disabled) { background: var(--c-accent-dim); }
 .chat-newchat:disabled { opacity: .45; }
 .chat-newchat-lg { margin: 14px auto 0; padding: 11px 18px; font-size: 14px; }
@@ -37,9 +37,27 @@
 .chat-project-head em { color: var(--c-accent); font-style: normal; font-size: 10px; }
 .chat-project-head button { color: var(--c-dim); padding: 2px; border-radius: 6px; }
 .chat-project-head button:hover { color: var(--c-text); background: var(--c-panel); }
-.chat-conv { display: block; width: 100%; text-align: left; padding: 7px 10px; border-radius: 8px; color: var(--c-text); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* New-chat dropdown */
+.chat-new { position: relative; padding: 0 12px; }
+.chat-newchat { width: 100%; }
+.chat-new-menu { position: absolute; left: 12px; right: 12px; top: 100%; margin-top: 4px; z-index: 10; background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 10px; padding: 6px; box-shadow: 0 8px 24px rgba(0,0,0,.4); max-height: 320px; overflow-y: auto; }
+.chat-new-menu button { display: block; width: 100%; text-align: left; padding: 7px 10px; border-radius: 7px; color: var(--c-text); font-size: 13px; }
+.chat-new-menu button:hover { background: var(--c-bg); }
+.chat-new-menu em { color: var(--c-accent); font-style: normal; font-size: 11px; }
+
+/* Search */
+.chat-search { display: flex; align-items: center; gap: 7px; margin: 12px 12px 8px; padding: 7px 10px; background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 9px; color: var(--c-dim); }
+.chat-search input { flex: 1; background: none; border: none; outline: none; color: var(--c-text); font: inherit; font-size: 13px; }
+
+/* Conversation list */
+.chat-convs { flex: 1; overflow-y: auto; padding: 0 8px 16px; }
+.chat-convs-empty { color: var(--c-dim); font-size: 12px; text-align: center; padding: 18px 0; }
+.chat-conv { display: flex; flex-direction: column; gap: 2px; width: 100%; text-align: left; padding: 8px 10px; border-radius: 9px; color: var(--c-text); }
 .chat-conv:hover { background: var(--c-panel); }
 .chat-conv-on { background: var(--c-panel); box-shadow: inset 2px 0 0 var(--c-accent); }
+.chat-conv-title { font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%; }
+.chat-conv-badge { align-self: flex-start; font-size: 10px; color: var(--c-dim); background: var(--c-bg); border: 1px solid var(--c-border); border-radius: 5px; padding: 1px 6px; }
+.chat-draft-hint { margin-top: 24vh; }
 
 /* Main */
 .chat-main { display: flex; flex-direction: column; overflow: hidden; }

--- a/apps/web/src/app/chat/chat.css
+++ b/apps/web/src/app/chat/chat.css
@@ -87,10 +87,18 @@
 .chat-tools span { font-size: 11px; color: var(--c-dim); background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 999px; padding: 2px 9px; }
 
 /* Composer */
-.chat-composer { border-top: 1px solid var(--c-border); background: var(--c-bg); padding: 12px 0 16px; }
+.chat-composer { border-top: 1px solid var(--c-border); background: var(--c-bg); padding: 16px 0 22px; }
 .chat-attachments, .chat-composer textarea, .chat-composer-bar { max-width: 760px; margin: 0 auto; padding: 0 28px; }
-.chat-attachments { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 8px; color: var(--c-dim); font-size: 12px; }
-.chat-composer textarea { display: block; width: 100%; box-sizing: border-box; background: var(--c-panel); color: var(--c-text); border: 1px solid var(--c-border); border-radius: 12px; padding: 12px 14px; resize: vertical; font: inherit; outline: none; }
+.chat-attachments { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 12px; }
+.chat-composer textarea { display: block; width: 100%; box-sizing: border-box; background: var(--c-panel); color: var(--c-text); border: 1px solid var(--c-border); border-radius: 14px; padding: 16px 18px; min-height: 76px; resize: vertical; font: inherit; line-height: 1.55; outline: none; }
+
+/* Attachment preview chips */
+.chat-attach { position: relative; width: 60px; height: 60px; }
+.chat-attach img { width: 60px; height: 60px; object-fit: cover; border-radius: 10px; border: 1px solid var(--c-border); display: block; }
+.chat-attach-loading { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,.4); border-radius: 10px; color: #fff; }
+.chat-attach-x { position: absolute; top: -7px; right: -7px; width: 20px; height: 20px; border-radius: 50%; background: var(--c-text); color: var(--c-bg); font-size: 14px; line-height: 1; display: flex; align-items: center; justify-content: center; box-shadow: 0 1px 3px rgba(0,0,0,.3); }
+.chat-attach-x:hover { background: var(--c-accent); }
+.chat-attach-name { display: none; }
 .chat-composer textarea:focus { border-color: var(--c-accent-dim); }
 .chat-composer-bar { display: flex; align-items: center; justify-content: space-between; margin-top: 8px; }
 .chat-composer-left { display: flex; align-items: center; gap: 10px; }

--- a/apps/web/src/app/chat/chat.css
+++ b/apps/web/src/app/chat/chat.css
@@ -1,12 +1,13 @@
+/* Inherit the app design system (globals.css tokens) instead of a bespoke theme. */
 :root {
-  --c-bg: #262624;
-  --c-side: #1c1b1a;
-  --c-panel: #30302e;
-  --c-border: #3a3937;
-  --c-text: #ece9e3;
-  --c-dim: #9c9893;
-  --c-accent: #d97757;
-  --c-accent-dim: #b85f43;
+  --c-bg: var(--background, #F7F6F4);
+  --c-side: var(--surface-subtle, #F0EEEb);
+  --c-panel: var(--surface, #FFFFFF);
+  --c-border: var(--border, #E5E0DB);
+  --c-text: var(--foreground, #1A1714);
+  --c-dim: var(--foreground-secondary, #6B6560);
+  --c-accent: var(--brand-accent, #A05040);
+  --c-accent-dim: #8a4537;
 }
 
 .chat-shell {
@@ -61,6 +62,23 @@
 
 /* Main */
 .chat-main { display: flex; flex-direction: column; overflow: hidden; }
+
+/* Mobile top bar (back to conversation list) — hidden on desktop */
+.chat-mobilebar { display: none; align-items: center; gap: 10px; padding: 10px 14px; border-bottom: 1px solid var(--c-border); background: var(--c-panel); }
+.chat-mobilebar button { display: inline-flex; color: var(--c-dim); padding: 6px; border-radius: 8px; }
+.chat-mobilebar button:hover { color: var(--c-text); background: var(--c-bg); }
+.chat-mobilebar .chat-mobilebar-title { font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ===== Mobile: collapse the sidebar when a chat is active ===== */
+@media (max-width: 768px) {
+  .chat-shell { grid-template-columns: 1fr; }
+  .chat-sidebar, .chat-main { grid-column: 1; grid-row: 1; min-width: 0; }
+  .chat-shell[data-sidebar="closed"] .chat-sidebar { display: none; }
+  .chat-shell[data-sidebar="open"] .chat-main { display: none; }
+  .chat-mobilebar { display: flex; }
+  .chat-msg { padding: 0 16px; }
+  .chat-attachments, .chat-composer textarea, .chat-composer-bar, .chat-status, .chat-questions { padding-left: 16px; padding-right: 16px; }
+}
 .chat-thread { flex: 1; overflow-y: auto; padding: 28px 0 24px; }
 .chat-msg { max-width: 760px; margin: 0 auto 22px; padding: 0 28px; }
 .chat-msg-user .chat-user-text { background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 14px; padding: 12px 16px; white-space: pre-wrap; }

--- a/apps/web/src/app/chat/chat.css
+++ b/apps/web/src/app/chat/chat.css
@@ -20,6 +20,11 @@
 .chat-sidebar { background: var(--c-side); border-right: 1px solid var(--c-border); display: flex; flex-direction: column; overflow: hidden; }
 .chat-profile { display: flex; align-items: center; gap: 8px; padding: 14px 14px 10px; color: var(--c-dim); }
 .chat-profile select { flex: 1; background: var(--c-panel); color: var(--c-text); border: 1px solid var(--c-border); border-radius: 8px; padding: 6px 8px; font-size: 13px; }
+.chat-bell { color: var(--c-dim); padding: 5px; border-radius: 8px; }
+.chat-bell:hover { color: var(--c-accent); background: var(--c-panel); }
+
+/* Working / queued status */
+.chat-status { max-width: 760px; margin: 0 auto 8px; padding: 0 28px; display: flex; align-items: center; gap: 7px; color: var(--c-dim); font-size: 12px; }
 .chat-projects { flex: 1; overflow-y: auto; padding: 6px 8px 16px; }
 .chat-project { margin-bottom: 14px; }
 .chat-project-head { display: flex; align-items: center; justify-content: space-between; color: var(--c-dim); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; padding: 4px 8px; }

--- a/apps/web/src/app/chat/chat.css
+++ b/apps/web/src/app/chat/chat.css
@@ -25,6 +25,11 @@
 
 /* Working / queued status */
 .chat-status { max-width: 760px; margin: 0 auto 8px; padding: 0 28px; display: flex; align-items: center; gap: 7px; color: var(--c-dim); font-size: 12px; }
+.chat-newchat { display: flex; align-items: center; justify-content: center; gap: 7px; margin: 4px 12px 8px; padding: 9px 12px; background: var(--c-accent); color: #fff; border-radius: 10px; font-weight: 600; font-size: 13px; }
+.chat-newchat:hover:not(:disabled) { background: var(--c-accent-dim); }
+.chat-newchat:disabled { opacity: .45; }
+.chat-newchat-lg { margin: 14px auto 0; padding: 11px 18px; font-size: 14px; }
+.chat-empty { color: var(--c-dim); text-align: center; margin-top: 20vh; display: flex; flex-direction: column; align-items: center; gap: 4px; }
 .chat-projects { flex: 1; overflow-y: auto; padding: 6px 8px 16px; }
 .chat-project { margin-bottom: 14px; }
 .chat-project-head { display: flex; align-items: center; justify-content: space-between; color: var(--c-dim); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; padding: 4px 8px; }
@@ -39,7 +44,6 @@
 /* Main */
 .chat-main { display: flex; flex-direction: column; overflow: hidden; }
 .chat-thread { flex: 1; overflow-y: auto; padding: 28px 0 24px; }
-.chat-empty { color: var(--c-dim); text-align: center; margin-top: 22vh; }
 .chat-msg { max-width: 760px; margin: 0 auto 22px; padding: 0 28px; }
 .chat-msg-user .chat-user-text { background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 14px; padding: 12px 16px; white-space: pre-wrap; }
 .chat-msg-assistant { color: var(--c-text); }

--- a/apps/web/src/app/chat/chat.css
+++ b/apps/web/src/app/chat/chat.css
@@ -15,6 +15,8 @@
   display: grid; grid-template-columns: 272px 1fr;
   background: var(--c-bg); color: var(--c-text);
   font: 14px/1.55 ui-sans-serif, system-ui, -apple-system, sans-serif;
+  overflow: hidden; max-width: 100vw;
+  -webkit-text-size-adjust: 100%; text-size-adjust: 100%;
 }
 
 /* Sidebar */
@@ -69,16 +71,6 @@
 .chat-mobilebar button:hover { color: var(--c-text); background: var(--c-bg); }
 .chat-mobilebar .chat-mobilebar-title { font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-/* ===== Mobile: collapse the sidebar when a chat is active ===== */
-@media (max-width: 768px) {
-  .chat-shell { grid-template-columns: 1fr; }
-  .chat-sidebar, .chat-main { grid-column: 1; grid-row: 1; min-width: 0; }
-  .chat-shell[data-sidebar="closed"] .chat-sidebar { display: none; }
-  .chat-shell[data-sidebar="open"] .chat-main { display: none; }
-  .chat-mobilebar { display: flex; }
-  .chat-msg { padding: 0 16px; }
-  .chat-attachments, .chat-composer textarea, .chat-composer-bar, .chat-status, .chat-questions { padding-left: 16px; padding-right: 16px; }
-}
 .chat-thread { flex: 1; overflow-y: auto; padding: 28px 0 24px; }
 .chat-msg { max-width: 760px; margin: 0 auto 22px; padding: 0 28px; }
 .chat-msg-user .chat-user-text { background: var(--c-panel); border: 1px solid var(--c-border); border-radius: 14px; padding: 12px 16px; white-space: pre-wrap; }
@@ -143,3 +135,17 @@
 .chat-prose th, .chat-prose td { border: 1px solid var(--c-border); padding: 6px 10px; text-align: left; }
 .chat-prose blockquote { border-left: 3px solid var(--c-border); margin: 0 0 12px; padding-left: 12px; color: var(--c-dim); }
 .chat-prose a { color: var(--c-accent); text-decoration: underline; }
+
+/* ===== Mobile: collapse the sidebar when a chat is active (must come last so
+   these overrides win the cascade against the base composer rules) ===== */
+@media (max-width: 768px) {
+  .chat-shell { grid-template-columns: 1fr; }
+  .chat-sidebar, .chat-main { grid-column: 1; grid-row: 1; min-width: 0; }
+  .chat-shell[data-sidebar="closed"] .chat-sidebar { display: none; }
+  .chat-shell[data-sidebar="open"] .chat-main { display: none; }
+  .chat-mobilebar { display: flex; }
+  .chat-msg { padding: 0 16px; }
+  .chat-attachments, .chat-composer textarea, .chat-composer-bar, .chat-status, .chat-questions { padding-left: 16px; padding-right: 16px; }
+  /* iOS zooms the page when a focused input is < 16px — force 16px to prevent it. */
+  .chat-composer textarea, .chat-search input, .chat-profile select, .chat-composer-left select { font-size: 16px; }
+}

--- a/apps/web/src/app/chat/layout.tsx
+++ b/apps/web/src/app/chat/layout.tsx
@@ -1,11 +1,21 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './chat.css';
+import { PwaRegister } from '@/components/chat/PwaRegister';
 
 export const metadata: Metadata = {
-  title: 'Chat',
+  title: 'Claude Chat',
+  manifest: '/chat.webmanifest',
   robots: { index: false, follow: false },
+  appleWebApp: { capable: true, statusBarStyle: 'black-translucent', title: 'Claude' },
+};
+
+export const viewport: Viewport = {
+  themeColor: '#262624',
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
 };
 
 export default function ChatLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return <>{children}<PwaRegister /></>;
 }

--- a/apps/web/src/app/chat/layout.tsx
+++ b/apps/web/src/app/chat/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import './chat.css';
+
+export const metadata: Metadata = {
+  title: 'Chat',
+  robots: { index: false, follow: false },
+};
+
+export default function ChatLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/web/src/app/chat/layout.tsx
+++ b/apps/web/src/app/chat/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: '#262624',
+  themeColor: '#F7F6F4',
   width: 'device-width',
   initialScale: 1,
   viewportFit: 'cover',

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -31,11 +31,24 @@ export default function ChatPage() {
   const [pending, setPending] = useState<{ name: string; path: string }[]>([]);
   const [running, setRunning] = useState(false);
   const [queued, setQueued] = useState(0);
+  const [ready, setReady] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
   const activeIdRef = useRef('');
 
-  useEffect(() => { getProfiles().then((r) => { setProfiles(r.profiles); if (r.profiles[0]) setProfileId(r.profiles[0].id); }).catch(() => {}); }, []);
+  // Auth gate: validate the session cookie; if not signed in, bounce to /login
+  // and come back to /chat afterwards. Without this, an unauthenticated visit
+  // just renders a dead empty sidebar (every /api/bridge call 401s).
+  useEffect(() => {
+    fetch('/api/v1/auth/validate')
+      .then((r) => { if (r.ok) setReady(true); else window.location.href = '/login?redirect=/chat'; })
+      .catch(() => window.location.href = '/login?redirect=/chat');
+  }, []);
+
+  useEffect(() => {
+    if (!ready) return;
+    getProfiles().then((r) => { setProfiles(r.profiles); if (r.profiles[0]) setProfileId(r.profiles[0].id); }).catch(() => {});
+  }, [ready]);
 
   useEffect(() => {
     if (!profileId) return;
@@ -125,6 +138,16 @@ export default function ChatPage() {
   const activeConv = conversations.find((c) => c.id === activeId);
   const lastIsUser = messages.length > 0 && messages[messages.length - 1].role === 'user';
   const showSpinner = running && lastIsUser && tools.length === 0;
+
+  if (!ready) {
+    return (
+      <div className="chat-shell" style={{ gridTemplateColumns: '1fr' }}>
+        <div className="chat-empty" style={{ margin: 'auto' }}>
+          <Loader className="chat-spin" size={20} /> Checking access…
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="chat-shell">

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -12,8 +12,11 @@ import { QuestionPanel } from '@/components/chat/QuestionPanel';
 import { enablePush } from '@/lib/chat/push-client';
 
 const MODELS = ['sonnet', 'opus', 'haiku'];
-type Draft = { text: string; tools: string[] };
 
+// Single source of truth: assistant segments stream straight into `messages`,
+// upserted by `seg-<assistant message id>`. Each assistant message is its own
+// sequential bubble — later messages never overwrite the lead-up — and upsert is
+// idempotent (safe under StrictMode double-subscription / stream reconnects).
 export default function ChatPage() {
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [profileId, setProfileId] = useState('');
@@ -21,7 +24,7 @@ export default function ChatPage() {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [activeId, setActiveId] = useState('');
   const [messages, setMessages] = useState<Message[]>([]);
-  const [draft, setDraft] = useState<Draft | null>(null);
+  const [tools, setTools] = useState<string[]>([]);
   const [questions, setQuestions] = useState<{ items: Question[] } | null>(null);
   const [input, setInput] = useState('');
   const [model, setModel] = useState('sonnet');
@@ -30,7 +33,7 @@ export default function ChatPage() {
   const [queued, setQueued] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
-  const seen = useRef<Set<string>>(new Set());
+  const activeIdRef = useRef('');
 
   useEffect(() => { getProfiles().then((r) => { setProfiles(r.profiles); if (r.profiles[0]) setProfileId(r.profiles[0].id); }).catch(() => {}); }, []);
 
@@ -41,53 +44,49 @@ export default function ChatPage() {
     setActiveId(''); setMessages([]);
   }, [profileId]);
 
-  // Load history + attach the live stream whenever the active conversation changes.
   useEffect(() => {
-    if (!activeId) { setMessages([]); setDraft(null); setQuestions(null); return; }
-    seen.current = new Set();
-    setDraft(null); setQuestions(null); setRunning(false); setQueued(0);
-    getMessages(activeId).then((r) => {
-      r.messages.forEach((m) => seen.current.add(m.id));
-      setMessages(r.messages);
-    }).catch(() => {});
-
+    activeIdRef.current = activeId;
+    if (!activeId) { setMessages([]); setTools([]); setQuestions(null); return; }
+    setTools([]); setQuestions(null); setRunning(false); setQueued(0);
+    getMessages(activeId).then((r) => setMessages(r.messages)).catch(() => {});
     const close = openStream(activeId, handleEvent);
     return () => close();
   }, [activeId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
-  }, [messages, draft, questions]);
+  }, [messages, tools, questions]);
 
   const refreshConvs = useCallback(() => {
     if (profileId) getConversations(profileId).then((r) => setConversations(r.conversations)).catch(() => {});
   }, [profileId]);
 
+  // Insert-or-update a message by id (idempotent).
+  function upsert(id: string, patch: Partial<Message> & { role: Message['role']; content: string }) {
+    setMessages((m) => {
+      const i = m.findIndex((x) => x.id === id);
+      if (i >= 0) {
+        if (m[i].content === patch.content) return m;
+        const next = m.slice(); next[i] = { ...next[i], ...patch }; return next;
+      }
+      return [...m, { id, conversationId: activeIdRef.current, attachments: null, createdAt: Date.now(), ...patch }];
+    });
+  }
+
   function handleEvent(e: BridgeEvent) {
     switch (e.type) {
       case 'sync': setRunning(e.running); setQueued(e.queued); break;
       case 'user':
-        if (seen.current.has(e.messageId)) break;
-        seen.current.add(e.messageId);
-        setMessages((m) => [...m, {
-          id: e.messageId, conversationId: activeId, role: 'user',
-          content: e.text + (e.attachments?.length ? `\n\n📎 ${e.attachments.length} file(s)` : ''),
-          attachments: null, createdAt: Date.now(),
-        }]);
+        upsert(e.messageId, { role: 'user', content: e.text + (e.attachments?.length ? `\n\n📎 ${e.attachments.length} file(s)` : '') });
         break;
-      case 'start': setRunning(true); setDraft({ text: '', tools: [] }); setQuestions(null); break;
-      case 'text': setDraft((d) => ({ text: e.text, tools: d?.tools ?? [] })); break;
-      case 'tool': setDraft((d) => ({ text: d?.text ?? '', tools: [...(d?.tools ?? []), e.name] })); break;
+      case 'start': setRunning(true); setTools([]); setQuestions(null); break;
+      case 'text': upsert(`seg-${e.messageId}`, { role: 'assistant', content: e.text }); break;
+      case 'tool': setTools((t) => (t[t.length - 1] === e.name ? t : [...t, e.name])); break;
       case 'questions': setQuestions({ items: e.questions }); break;
-      case 'error':
-        setMessages((m) => [...m, { id: `e-${Date.now()}`, conversationId: activeId, role: 'assistant', content: `⚠️ ${e.message}`, attachments: null, createdAt: Date.now() }]);
-        break;
-      case 'done':
-        if (e.text) setMessages((m) => [...m, { id: `a-${Date.now()}-${Math.random()}`, conversationId: activeId, role: 'assistant', content: e.text, attachments: null, createdAt: Date.now() }]);
-        setDraft(null); refreshConvs();
-        break;
-      case 'end': setQueued((q) => Math.max(0, q - 1)); break;
-      case 'idle': setRunning(false); setQueued(0); setDraft(null); break;
+      case 'error': upsert(`err-${Date.now()}`, { role: 'assistant', content: `⚠️ ${e.message}` }); break;
+      case 'done': break;
+      case 'end': setQueued((q) => Math.max(0, q - 1)); setTools([]); refreshConvs(); break;
+      case 'idle': setRunning(false); setQueued(0); setTools([]); break;
     }
   }
 
@@ -109,7 +108,6 @@ export default function ChatPage() {
     if (!prompt || !activeId) return;
     const attachments = pending.map((p) => p.path);
     setInput(''); setPending([]);
-    // Fire-and-forget — the user bubble + response arrive via the stream.
     await sendMessage({ conversationId: activeId, prompt, model, attachments }).catch(() => {});
   }
 
@@ -120,6 +118,8 @@ export default function ChatPage() {
   }
 
   const activeConv = conversations.find((c) => c.id === activeId);
+  const lastIsUser = messages.length > 0 && messages[messages.length - 1].role === 'user';
+  const showSpinner = running && lastIsUser && tools.length === 0;
 
   return (
     <div className="chat-shell">
@@ -154,12 +154,8 @@ export default function ChatPage() {
               {m.role === 'assistant' ? <Markdown>{m.content}</Markdown> : <div className="chat-user-text">{m.content}</div>}
             </div>
           ))}
-          {draft && (
-            <div className="chat-msg chat-msg-assistant">
-              {draft.tools.length > 0 && <div className="chat-tools">{draft.tools.map((t, i) => <span key={i}>{t}</span>)}</div>}
-              {draft.text ? <Markdown>{draft.text}</Markdown> : <Loader className="chat-spin" size={16} />}
-            </div>
-          )}
+          {tools.length > 0 && <div className="chat-msg chat-msg-assistant"><div className="chat-tools">{tools.map((t, i) => <span key={i}>{t}</span>)}</div></div>}
+          {showSpinner && <div className="chat-msg chat-msg-assistant"><Loader className="chat-spin" size={16} /></div>}
           {questions && <QuestionPanel questions={questions.items} onSubmit={submitAnswers} />}
         </div>
 

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Plus, Send, Paperclip, Loader, Hash, User, Bell } from 'lucide-react';
 import {
-  getProfiles, getProjects, getConversations, getMessages,
+  getProjects, getConversations, getMessages,
   createConversation, sendMessage, openStream, uploadFile,
   type Profile, type Project, type Conversation, type Message, type Question, type BridgeEvent,
 } from '@/lib/chat/api';
@@ -36,19 +36,21 @@ export default function ChatPage() {
   const fileRef = useRef<HTMLInputElement>(null);
   const activeIdRef = useRef('');
 
-  // Auth gate: validate the session cookie; if not signed in, bounce to /login
-  // and come back to /chat afterwards. Without this, an unauthenticated visit
-  // just renders a dead empty sidebar (every /api/bridge call 401s).
+  // Auth gate + initial load in one. Validates via a COOKIE-AWARE endpoint
+  // (the bridge proxy uses validateApiAuth which reads the bearerToken cookie).
+  // NOTE: /api/v1/auth/validate only checks the Authorization header, not the
+  // cookie — using it here caused an infinite login loop.
   useEffect(() => {
-    fetch('/api/v1/auth/validate')
-      .then((r) => { if (r.ok) setReady(true); else window.location.href = '/login?redirect=/chat'; })
-      .catch(() => window.location.href = '/login?redirect=/chat');
+    fetch('/api/bridge/profiles')
+      .then(async (r) => {
+        if (r.status === 401) { window.location.href = '/login?redirect=/chat'; return; }
+        const d = await r.json().catch(() => ({ profiles: [] }));
+        setProfiles(d.profiles ?? []);
+        if (d.profiles?.[0]) setProfileId(d.profiles[0].id);
+        setReady(true); // authed (even if bridge errored — that's a different problem, don't loop)
+      })
+      .catch(() => setReady(true));
   }, []);
-
-  useEffect(() => {
-    if (!ready) return;
-    getProfiles().then((r) => { setProfiles(r.profiles); if (r.profiles[0]) setProfileId(r.profiles[0].id); }).catch(() => {});
-  }, [ready]);
 
   useEffect(() => {
     if (!profileId) return;

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -1,40 +1,38 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Plus, Send, Paperclip, Loader, Hash, User } from 'lucide-react';
+import { Plus, Send, Paperclip, Loader, Hash, User, Bell } from 'lucide-react';
 import {
   getProfiles, getProjects, getConversations, getMessages,
-  createConversation, streamChat, uploadFile,
-  type Profile, type Project, type Conversation, type Message, type Question,
+  createConversation, sendMessage, openStream, uploadFile,
+  type Profile, type Project, type Conversation, type Message, type Question, type BridgeEvent,
 } from '@/lib/chat/api';
 import { Markdown } from '@/components/chat/Markdown';
 import { QuestionPanel } from '@/components/chat/QuestionPanel';
+import { enablePush } from '@/lib/chat/push-client';
 
 const MODELS = ['sonnet', 'opus', 'haiku'];
-
 type Draft = { text: string; tools: string[] };
 
 export default function ChatPage() {
   const [profiles, setProfiles] = useState<Profile[]>([]);
-  const [profileId, setProfileId] = useState<string>('');
+  const [profileId, setProfileId] = useState('');
   const [projects, setProjects] = useState<Project[]>([]);
   const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [activeId, setActiveId] = useState<string>('');
+  const [activeId, setActiveId] = useState('');
   const [messages, setMessages] = useState<Message[]>([]);
   const [draft, setDraft] = useState<Draft | null>(null);
   const [questions, setQuestions] = useState<{ items: Question[] } | null>(null);
   const [input, setInput] = useState('');
   const [model, setModel] = useState('sonnet');
   const [pending, setPending] = useState<{ name: string; path: string }[]>([]);
-  const [busy, setBusy] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [queued, setQueued] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const seen = useRef<Set<string>>(new Set());
 
-  // ---- Loaders ----
-  useEffect(() => { getProfiles().then((r) => {
-    setProfiles(r.profiles);
-    if (r.profiles[0]) setProfileId(r.profiles[0].id);
-  }).catch(() => {}); }, []);
+  useEffect(() => { getProfiles().then((r) => { setProfiles(r.profiles); if (r.profiles[0]) setProfileId(r.profiles[0].id); }).catch(() => {}); }, []);
 
   useEffect(() => {
     if (!profileId) return;
@@ -43,67 +41,76 @@ export default function ChatPage() {
     setActiveId(''); setMessages([]);
   }, [profileId]);
 
+  // Load history + attach the live stream whenever the active conversation changes.
   useEffect(() => {
-    if (!activeId) { setMessages([]); return; }
-    getMessages(activeId).then((r) => setMessages(r.messages)).catch(() => {});
-    const conv = conversations.find((c) => c.id === activeId);
-    if (conv?.model) setModel(conv.model);
+    if (!activeId) { setMessages([]); setDraft(null); setQuestions(null); return; }
+    seen.current = new Set();
+    setDraft(null); setQuestions(null); setRunning(false); setQueued(0);
+    getMessages(activeId).then((r) => {
+      r.messages.forEach((m) => seen.current.add(m.id));
+      setMessages(r.messages);
+    }).catch(() => {});
+
+    const close = openStream(activeId, handleEvent);
+    return () => close();
   }, [activeId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
   }, [messages, draft, questions]);
 
-  const refreshConversations = useCallback(() => {
+  const refreshConvs = useCallback(() => {
     if (profileId) getConversations(profileId).then((r) => setConversations(r.conversations)).catch(() => {});
   }, [profileId]);
 
-  // ---- Actions ----
+  function handleEvent(e: BridgeEvent) {
+    switch (e.type) {
+      case 'sync': setRunning(e.running); setQueued(e.queued); break;
+      case 'user':
+        if (seen.current.has(e.messageId)) break;
+        seen.current.add(e.messageId);
+        setMessages((m) => [...m, {
+          id: e.messageId, conversationId: activeId, role: 'user',
+          content: e.text + (e.attachments?.length ? `\n\n📎 ${e.attachments.length} file(s)` : ''),
+          attachments: null, createdAt: Date.now(),
+        }]);
+        break;
+      case 'start': setRunning(true); setDraft({ text: '', tools: [] }); setQuestions(null); break;
+      case 'text': setDraft((d) => ({ text: e.text, tools: d?.tools ?? [] })); break;
+      case 'tool': setDraft((d) => ({ text: d?.text ?? '', tools: [...(d?.tools ?? []), e.name] })); break;
+      case 'questions': setQuestions({ items: e.questions }); break;
+      case 'error':
+        setMessages((m) => [...m, { id: `e-${Date.now()}`, conversationId: activeId, role: 'assistant', content: `⚠️ ${e.message}`, attachments: null, createdAt: Date.now() }]);
+        break;
+      case 'done':
+        if (e.text) setMessages((m) => [...m, { id: `a-${Date.now()}-${Math.random()}`, conversationId: activeId, role: 'assistant', content: e.text, attachments: null, createdAt: Date.now() }]);
+        setDraft(null); refreshConvs();
+        break;
+      case 'end': setQueued((q) => Math.max(0, q - 1)); break;
+      case 'idle': setRunning(false); setQueued(0); setDraft(null); break;
+    }
+  }
+
   async function newConversation(projectId: string) {
     const r = await createConversation(projectId, profileId, model);
     setConversations((c) => [r.conversation, ...c]);
-    setActiveId(r.conversation.id);
-    setMessages([]);
+    setActiveId(r.conversation.id); setMessages([]);
   }
 
   async function onPickFiles(files: FileList | null) {
     if (!files || !activeId) return;
     for (const f of Array.from(files)) {
-      try { const path = await uploadFile(activeId, f); setPending((p) => [...p, { name: f.name, path }]); }
-      catch { /* ignore */ }
+      try { const path = await uploadFile(activeId, f); setPending((p) => [...p, { name: f.name, path }]); } catch { /* */ }
     }
   }
 
   async function send(promptOverride?: string) {
     const prompt = (promptOverride ?? input).trim();
-    if (!prompt || !activeId || busy) return;
+    if (!prompt || !activeId) return;
     const attachments = pending.map((p) => p.path);
-    setMessages((m) => [...m, {
-      id: `local-${Date.now()}`, conversationId: activeId, role: 'user',
-      content: prompt + (pending.length ? `\n\n📎 ${pending.map((p) => p.name).join(', ')}` : ''),
-      attachments: null, createdAt: Date.now(),
-    }]);
-    setInput(''); setPending([]); setBusy(true);
-    setDraft({ text: '', tools: [] }); setQuestions(null);
-
-    let finalText = '';
-    await streamChat({ conversationId: activeId, prompt, model, attachments }, {
-      onText: (text) => { finalText = text; setDraft((d) => ({ text, tools: d?.tools ?? [] })); },
-      onTool: (name) => setDraft((d) => ({ text: d?.text ?? '', tools: [...(d?.tools ?? []), name] })),
-      onQuestions: (items) => setQuestions({ items }),
-      onError: (msg) => { finalText = (finalText ? finalText + '\n\n' : '') + `⚠️ ${msg}`; },
-      onDone: (text) => { if (text) finalText = text; },
-    }).catch((e) => { finalText = `⚠️ ${e.message}`; });
-
-    setDraft(null);
-    setBusy(false);
-    if (finalText) {
-      setMessages((m) => [...m, {
-        id: `a-${Date.now()}`, conversationId: activeId, role: 'assistant',
-        content: finalText, attachments: null, createdAt: Date.now(),
-      }]);
-    }
-    refreshConversations();
+    setInput(''); setPending([]);
+    // Fire-and-forget — the user bubble + response arrive via the stream.
+    await sendMessage({ conversationId: activeId, prompt, model, attachments }).catch(() => {});
   }
 
   function submitAnswers(answers: { question: string; answer: string }[]) {
@@ -116,15 +123,14 @@ export default function ChatPage() {
 
   return (
     <div className="chat-shell">
-      {/* Sidebar */}
       <aside className="chat-sidebar">
         <div className="chat-profile">
           <User size={15} />
           <select value={profileId} onChange={(e) => setProfileId(e.target.value)}>
             {profiles.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
           </select>
+          <button title="Enable notifications" className="chat-bell" onClick={() => profileId && enablePush(profileId)}><Bell size={15} /></button>
         </div>
-
         <div className="chat-projects">
           {projects.map((proj) => (
             <div key={proj.id} className="chat-project">
@@ -133,18 +139,13 @@ export default function ChatPage() {
                 <button title="New conversation" onClick={() => newConversation(proj.id)}><Plus size={14} /></button>
               </div>
               {conversations.filter((c) => c.projectId === proj.id).map((c) => (
-                <button
-                  key={c.id}
-                  className={`chat-conv ${c.id === activeId ? 'chat-conv-on' : ''}`}
-                  onClick={() => setActiveId(c.id)}
-                >{c.title}</button>
+                <button key={c.id} className={`chat-conv ${c.id === activeId ? 'chat-conv-on' : ''}`} onClick={() => setActiveId(c.id)}>{c.title}</button>
               ))}
             </div>
           ))}
         </div>
       </aside>
 
-      {/* Main */}
       <main className="chat-main">
         <div className="chat-thread" ref={scrollRef}>
           {!activeId && <div className="chat-empty">Pick a project and start a conversation.</div>}
@@ -155,43 +156,43 @@ export default function ChatPage() {
           ))}
           {draft && (
             <div className="chat-msg chat-msg-assistant">
-              {draft.tools.length > 0 && (
-                <div className="chat-tools">{draft.tools.map((t, i) => <span key={i}>{t}</span>)}</div>
-              )}
+              {draft.tools.length > 0 && <div className="chat-tools">{draft.tools.map((t, i) => <span key={i}>{t}</span>)}</div>}
               {draft.text ? <Markdown>{draft.text}</Markdown> : <Loader className="chat-spin" size={16} />}
             </div>
           )}
           {questions && <QuestionPanel questions={questions.items} onSubmit={submitAnswers} />}
         </div>
 
-        {activeId && !questions && (
+        {activeId && (
           <div className="chat-composer">
-            {pending.length > 0 && (
-              <div className="chat-attachments">
-                {pending.map((p, i) => <span key={i}>📎 {p.name}</span>)}
+            {(running || queued > 1) && (
+              <div className="chat-status">
+                <Loader className="chat-spin" size={12} /> {running ? 'Working…' : ''}{queued > 1 ? ` ${queued - 1} queued` : ''} — keep typing, messages queue
               </div>
             )}
-            <textarea
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); send(); } }}
-              placeholder="Message… (⌘↵ to send). Dictate freely — no length limit."
-              rows={3}
-            />
-            <div className="chat-composer-bar">
-              <div className="chat-composer-left">
-                <button onClick={() => fileRef.current?.click()} title="Attach image"><Paperclip size={16} /></button>
-                <input ref={fileRef} type="file" accept="image/*" multiple hidden
-                  onChange={(e) => onPickFiles(e.target.files)} />
-                <select value={model} onChange={(e) => setModel(e.target.value)}>
-                  {MODELS.map((m) => <option key={m} value={m}>{m}</option>)}
-                </select>
-                {activeConv && <span className="chat-cwd">{activeConv.title}</span>}
-              </div>
-              <button className="chat-send" onClick={() => send()} disabled={busy || !input.trim()}>
-                {busy ? <Loader className="chat-spin" size={16} /> : <Send size={16} />}
-              </button>
-            </div>
+            {pending.length > 0 && <div className="chat-attachments">{pending.map((p, i) => <span key={i}>📎 {p.name}</span>)}</div>}
+            {!questions && (
+              <>
+                <textarea
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); send(); } }}
+                  placeholder="Message… (⌘↵ to send). Send freely — messages queue while it works."
+                  rows={3}
+                />
+                <div className="chat-composer-bar">
+                  <div className="chat-composer-left">
+                    <button onClick={() => fileRef.current?.click()} title="Attach image"><Paperclip size={16} /></button>
+                    <input ref={fileRef} type="file" accept="image/*" multiple hidden onChange={(e) => onPickFiles(e.target.files)} />
+                    <select value={model} onChange={(e) => setModel(e.target.value)}>{MODELS.map((m) => <option key={m} value={m}>{m}</option>)}</select>
+                    {activeConv && <span className="chat-cwd">{activeConv.title}</span>}
+                  </div>
+                  <button className="chat-send" onClick={() => send()} disabled={!input.trim()}>
+                    <Send size={16} />
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         )}
       </main>

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Plus, Send, Paperclip, Loader, Hash, User } from 'lucide-react';
+import {
+  getProfiles, getProjects, getConversations, getMessages,
+  createConversation, streamChat, uploadFile,
+  type Profile, type Project, type Conversation, type Message, type Question,
+} from '@/lib/chat/api';
+import { Markdown } from '@/components/chat/Markdown';
+import { QuestionPanel } from '@/components/chat/QuestionPanel';
+
+const MODELS = ['sonnet', 'opus', 'haiku'];
+
+type Draft = { text: string; tools: string[] };
+
+export default function ChatPage() {
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [profileId, setProfileId] = useState<string>('');
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [activeId, setActiveId] = useState<string>('');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const [questions, setQuestions] = useState<{ items: Question[] } | null>(null);
+  const [input, setInput] = useState('');
+  const [model, setModel] = useState('sonnet');
+  const [pending, setPending] = useState<{ name: string; path: string }[]>([]);
+  const [busy, setBusy] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  // ---- Loaders ----
+  useEffect(() => { getProfiles().then((r) => {
+    setProfiles(r.profiles);
+    if (r.profiles[0]) setProfileId(r.profiles[0].id);
+  }).catch(() => {}); }, []);
+
+  useEffect(() => {
+    if (!profileId) return;
+    getProjects(profileId).then((r) => setProjects(r.projects)).catch(() => {});
+    getConversations(profileId).then((r) => setConversations(r.conversations)).catch(() => {});
+    setActiveId(''); setMessages([]);
+  }, [profileId]);
+
+  useEffect(() => {
+    if (!activeId) { setMessages([]); return; }
+    getMessages(activeId).then((r) => setMessages(r.messages)).catch(() => {});
+    const conv = conversations.find((c) => c.id === activeId);
+    if (conv?.model) setModel(conv.model);
+  }, [activeId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [messages, draft, questions]);
+
+  const refreshConversations = useCallback(() => {
+    if (profileId) getConversations(profileId).then((r) => setConversations(r.conversations)).catch(() => {});
+  }, [profileId]);
+
+  // ---- Actions ----
+  async function newConversation(projectId: string) {
+    const r = await createConversation(projectId, profileId, model);
+    setConversations((c) => [r.conversation, ...c]);
+    setActiveId(r.conversation.id);
+    setMessages([]);
+  }
+
+  async function onPickFiles(files: FileList | null) {
+    if (!files || !activeId) return;
+    for (const f of Array.from(files)) {
+      try { const path = await uploadFile(activeId, f); setPending((p) => [...p, { name: f.name, path }]); }
+      catch { /* ignore */ }
+    }
+  }
+
+  async function send(promptOverride?: string) {
+    const prompt = (promptOverride ?? input).trim();
+    if (!prompt || !activeId || busy) return;
+    const attachments = pending.map((p) => p.path);
+    setMessages((m) => [...m, {
+      id: `local-${Date.now()}`, conversationId: activeId, role: 'user',
+      content: prompt + (pending.length ? `\n\n📎 ${pending.map((p) => p.name).join(', ')}` : ''),
+      attachments: null, createdAt: Date.now(),
+    }]);
+    setInput(''); setPending([]); setBusy(true);
+    setDraft({ text: '', tools: [] }); setQuestions(null);
+
+    let finalText = '';
+    await streamChat({ conversationId: activeId, prompt, model, attachments }, {
+      onText: (text) => { finalText = text; setDraft((d) => ({ text, tools: d?.tools ?? [] })); },
+      onTool: (name) => setDraft((d) => ({ text: d?.text ?? '', tools: [...(d?.tools ?? []), name] })),
+      onQuestions: (items) => setQuestions({ items }),
+      onError: (msg) => { finalText = (finalText ? finalText + '\n\n' : '') + `⚠️ ${msg}`; },
+      onDone: (text) => { if (text) finalText = text; },
+    }).catch((e) => { finalText = `⚠️ ${e.message}`; });
+
+    setDraft(null);
+    setBusy(false);
+    if (finalText) {
+      setMessages((m) => [...m, {
+        id: `a-${Date.now()}`, conversationId: activeId, role: 'assistant',
+        content: finalText, attachments: null, createdAt: Date.now(),
+      }]);
+    }
+    refreshConversations();
+  }
+
+  function submitAnswers(answers: { question: string; answer: string }[]) {
+    const reply = answers.map((a) => `${a.question}\n→ ${a.answer}`).join('\n\n');
+    setQuestions(null);
+    send(reply);
+  }
+
+  const activeConv = conversations.find((c) => c.id === activeId);
+
+  return (
+    <div className="chat-shell">
+      {/* Sidebar */}
+      <aside className="chat-sidebar">
+        <div className="chat-profile">
+          <User size={15} />
+          <select value={profileId} onChange={(e) => setProfileId(e.target.value)}>
+            {profiles.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+          </select>
+        </div>
+
+        <div className="chat-projects">
+          {projects.map((proj) => (
+            <div key={proj.id} className="chat-project">
+              <div className="chat-project-head">
+                <span><Hash size={13} /> {proj.name}{proj.scope === 'shared' && <em> · shared</em>}</span>
+                <button title="New conversation" onClick={() => newConversation(proj.id)}><Plus size={14} /></button>
+              </div>
+              {conversations.filter((c) => c.projectId === proj.id).map((c) => (
+                <button
+                  key={c.id}
+                  className={`chat-conv ${c.id === activeId ? 'chat-conv-on' : ''}`}
+                  onClick={() => setActiveId(c.id)}
+                >{c.title}</button>
+              ))}
+            </div>
+          ))}
+        </div>
+      </aside>
+
+      {/* Main */}
+      <main className="chat-main">
+        <div className="chat-thread" ref={scrollRef}>
+          {!activeId && <div className="chat-empty">Pick a project and start a conversation.</div>}
+          {messages.map((m) => (
+            <div key={m.id} className={`chat-msg chat-msg-${m.role}`}>
+              {m.role === 'assistant' ? <Markdown>{m.content}</Markdown> : <div className="chat-user-text">{m.content}</div>}
+            </div>
+          ))}
+          {draft && (
+            <div className="chat-msg chat-msg-assistant">
+              {draft.tools.length > 0 && (
+                <div className="chat-tools">{draft.tools.map((t, i) => <span key={i}>{t}</span>)}</div>
+              )}
+              {draft.text ? <Markdown>{draft.text}</Markdown> : <Loader className="chat-spin" size={16} />}
+            </div>
+          )}
+          {questions && <QuestionPanel questions={questions.items} onSubmit={submitAnswers} />}
+        </div>
+
+        {activeId && !questions && (
+          <div className="chat-composer">
+            {pending.length > 0 && (
+              <div className="chat-attachments">
+                {pending.map((p, i) => <span key={i}>📎 {p.name}</span>)}
+              </div>
+            )}
+            <textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); send(); } }}
+              placeholder="Message… (⌘↵ to send). Dictate freely — no length limit."
+              rows={3}
+            />
+            <div className="chat-composer-bar">
+              <div className="chat-composer-left">
+                <button onClick={() => fileRef.current?.click()} title="Attach image"><Paperclip size={16} /></button>
+                <input ref={fileRef} type="file" accept="image/*" multiple hidden
+                  onChange={(e) => onPickFiles(e.target.files)} />
+                <select value={model} onChange={(e) => setModel(e.target.value)}>
+                  {MODELS.map((m) => <option key={m} value={m}>{m}</option>)}
+                </select>
+                {activeConv && <span className="chat-cwd">{activeConv.title}</span>}
+              </div>
+              <button className="chat-send" onClick={() => send()} disabled={busy || !input.trim()}>
+                {busy ? <Loader className="chat-spin" size={16} /> : <Send size={16} />}
+              </button>
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -25,7 +25,7 @@ export default function ChatPage() {
   const [questions, setQuestions] = useState<{ items: Question[] } | null>(null);
   const [input, setInput] = useState('');
   const [model, setModel] = useState('sonnet');
-  const [pending, setPending] = useState<{ name: string; path: string }[]>([]);
+  const [pending, setPending] = useState<{ id: string; name: string; url: string; path?: string; uploading: boolean }[]>([]);
   const [running, setRunning] = useState(false);
   const [queued, setQueued] = useState(0);
   const [ready, setReady] = useState(false);
@@ -135,9 +135,19 @@ export default function ChatPage() {
     if (!files) return;
     const convId = activeId || 'draft';
     for (const f of Array.from(files)) {
-      try { const path = await uploadFile(convId, f); setPending((p) => [...p, { name: f.name, path }]); } catch { /* */ }
+      const id = `${Date.now()}-${f.name}`;
+      // Show the chip immediately (with a local preview + spinner), then fill in the path.
+      setPending((p) => [...p, { id, name: f.name, url: URL.createObjectURL(f), uploading: true }]);
+      try {
+        const path = await uploadFile(convId, f);
+        setPending((p) => p.map((x) => (x.id === id ? { ...x, path, uploading: false } : x)));
+      } catch {
+        setPending((p) => p.filter((x) => x.id !== id));
+      }
     }
   }
+
+  const removePending = (id: string) => setPending((p) => p.filter((x) => x.id !== id));
 
   async function send(promptOverride?: string) {
     const prompt = (promptOverride ?? input).trim();
@@ -152,7 +162,7 @@ export default function ChatPage() {
       setActiveId(convId);
     }
     if (!convId) return;
-    const attachments = pending.map((p) => p.path);
+    const attachments = pending.map((p) => p.path).filter((x): x is string => !!x);
     setInput(''); setPending([]);
     await sendMessage({ conversationId: convId, prompt, model, attachments }).catch(() => {});
   }
@@ -248,7 +258,18 @@ export default function ChatPage() {
             {(running || queued > 1) && (
               <div className="chat-status"><Loader className="chat-spin" size={12} /> {running ? 'Working…' : ''}{queued > 1 ? ` ${queued - 1} queued` : ''} — keep typing, messages queue</div>
             )}
-            {pending.length > 0 && <div className="chat-attachments">{pending.map((p, i) => <span key={i}>📎 {p.name}</span>)}</div>}
+            {pending.length > 0 && (
+              <div className="chat-attachments">
+                {pending.map((p) => (
+                  <div key={p.id} className="chat-attach">
+                    <img src={p.url} alt={p.name} />
+                    {p.uploading && <div className="chat-attach-loading"><Loader className="chat-spin" size={14} /></div>}
+                    <button className="chat-attach-x" onClick={() => removePending(p.id)} aria-label="Remove">×</button>
+                    <span className="chat-attach-name">{p.name}</span>
+                  </div>
+                ))}
+              </div>
+            )}
             {!questions && (
               <>
                 <textarea

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Plus, Send, Paperclip, Loader, User, Bell, Search, ChevronDown } from 'lucide-react';
+import { Plus, Send, Paperclip, Loader, User, Bell, Search, ChevronDown, Menu } from 'lucide-react';
 import {
   getProjects, getConversations, getMessages, searchConversations,
   createConversation, sendMessage, openStream, uploadFile,
@@ -32,6 +32,7 @@ export default function ChatPage() {
   const [newOpen, setNewOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [results, setResults] = useState<Conversation[] | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false); // mobile: collapsed when a chat is active
   const scrollRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
   const activeIdRef = useRef('');
@@ -39,7 +40,6 @@ export default function ChatPage() {
   // Auth gate via the cookie-aware bridge proxy (NOT /api/v1/auth/validate, which
   // is header-only and caused a login loop).
   useEffect(() => {
-    getProjects('evan').catch(() => null); // warm
     fetch('/api/bridge/profiles')
       .then(async (r) => {
         if (r.status === 401) { window.location.href = '/login?redirect=/chat'; return; }
@@ -53,9 +53,14 @@ export default function ChatPage() {
 
   useEffect(() => {
     if (!profileId) return;
-    getProjects(profileId).then((r) => setProjects(r.projects)).catch(() => {});
+    setActiveId(''); setMessages([]); setSearch(''); setResults(null);
     getConversations(profileId).then((r) => setConversations(r.conversations)).catch(() => {});
-    setActiveId(''); setDraftProjectId(null); setMessages([]); setSearch(''); setResults(null);
+    getProjects(profileId).then((r) => {
+      setProjects(r.projects);
+      // Default to a new active chat (General) so the composer is ready immediately.
+      const gen = r.projects.find((p) => /general/i.test(p.name)) ?? r.projects[0];
+      setDraftProjectId(gen ? gen.id : null);
+    }).catch(() => {});
   }, [profileId]);
 
   useEffect(() => {
@@ -117,11 +122,13 @@ export default function ChatPage() {
     setActiveId('');
     setDraftProjectId(projectId);
     setMessages([]); setTools([]); setQuestions(null);
+    setSidebarOpen(false); // mobile: jump into the chat
   }
 
   function openConversation(id: string) {
     setDraftProjectId(null);
     setActiveId(id);
+    setSidebarOpen(false); // mobile: collapse the list, show the chat
   }
 
   async function onPickFiles(files: FileList | null) {
@@ -157,6 +164,7 @@ export default function ChatPage() {
   }
 
   const projectName = (id: string) => projects.find((p) => p.id === id)?.name ?? '';
+  const activeConv = conversations.find((c) => c.id === activeId);
   const list = results ?? conversations;
   const composing = !!activeId || !!draftProjectId;
   const lastIsUser = messages.length > 0 && messages[messages.length - 1].role === 'user';
@@ -171,7 +179,7 @@ export default function ChatPage() {
   }
 
   return (
-    <div className="chat-shell">
+    <div className="chat-shell" data-sidebar={sidebarOpen ? 'open' : 'closed'}>
       <aside className="chat-sidebar">
         <div className="chat-profile">
           <User size={15} />
@@ -216,6 +224,10 @@ export default function ChatPage() {
       </aside>
 
       <main className="chat-main">
+        <div className="chat-mobilebar">
+          <button onClick={() => setSidebarOpen(true)} aria-label="Conversations"><Menu size={18} /></button>
+          <span className="chat-mobilebar-title">{activeConv?.title ?? (draftProjectId ? `New chat · ${projectName(draftProjectId)}` : 'Chat')}</span>
+        </div>
         <div className="chat-thread" ref={scrollRef}>
           {!composing && <div className="chat-empty">Start a new chat or pick a conversation.</div>}
           {composing && messages.length === 0 && (

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -112,6 +112,7 @@ export default function ChatPage() {
       case 'questions': setQuestions({ items: e.questions }); break;
       case 'error': upsert(`err-${Date.now()}`, { role: 'assistant', content: `⚠️ ${e.message}` }); break;
       case 'done': break;
+      case 'title': setConversations((cs) => cs.map((c) => (c.id === e.conversationId ? { ...c, title: e.title } : c))); break;
       case 'end': setQueued((q) => Math.max(0, q - 1)); setTools([]); refreshConvs(); break;
       case 'idle': setRunning(false); setQueued(0); setTools([]); break;
     }

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Plus, Send, Paperclip, Loader, Hash, User, Bell } from 'lucide-react';
+import { Plus, Send, Paperclip, Loader, User, Bell, Search, ChevronDown } from 'lucide-react';
 import {
-  getProjects, getConversations, getMessages,
+  getProjects, getConversations, getMessages, searchConversations,
   createConversation, sendMessage, openStream, uploadFile,
   type Profile, type Project, type Conversation, type Message, type Question, type BridgeEvent,
 } from '@/lib/chat/api';
@@ -13,16 +13,13 @@ import { enablePush } from '@/lib/chat/push-client';
 
 const MODELS = ['sonnet', 'opus', 'haiku'];
 
-// Single source of truth: assistant segments stream straight into `messages`,
-// upserted by `seg-<assistant message id>`. Each assistant message is its own
-// sequential bubble — later messages never overwrite the lead-up — and upsert is
-// idempotent (safe under StrictMode double-subscription / stream reconnects).
 export default function ChatPage() {
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [profileId, setProfileId] = useState('');
   const [projects, setProjects] = useState<Project[]>([]);
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [activeId, setActiveId] = useState('');
+  const [draftProjectId, setDraftProjectId] = useState<string | null>(null); // new chat, not yet created
   const [messages, setMessages] = useState<Message[]>([]);
   const [tools, setTools] = useState<string[]>([]);
   const [questions, setQuestions] = useState<{ items: Question[] } | null>(null);
@@ -32,22 +29,24 @@ export default function ChatPage() {
   const [running, setRunning] = useState(false);
   const [queued, setQueued] = useState(0);
   const [ready, setReady] = useState(false);
+  const [newOpen, setNewOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [results, setResults] = useState<Conversation[] | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
   const activeIdRef = useRef('');
 
-  // Auth gate + initial load in one. Validates via a COOKIE-AWARE endpoint
-  // (the bridge proxy uses validateApiAuth which reads the bearerToken cookie).
-  // NOTE: /api/v1/auth/validate only checks the Authorization header, not the
-  // cookie — using it here caused an infinite login loop.
+  // Auth gate via the cookie-aware bridge proxy (NOT /api/v1/auth/validate, which
+  // is header-only and caused a login loop).
   useEffect(() => {
+    getProjects('evan').catch(() => null); // warm
     fetch('/api/bridge/profiles')
       .then(async (r) => {
         if (r.status === 401) { window.location.href = '/login?redirect=/chat'; return; }
         const d = await r.json().catch(() => ({ profiles: [] }));
         setProfiles(d.profiles ?? []);
         if (d.profiles?.[0]) setProfileId(d.profiles[0].id);
-        setReady(true); // authed (even if bridge errored — that's a different problem, don't loop)
+        setReady(true);
       })
       .catch(() => setReady(true));
   }, []);
@@ -56,7 +55,7 @@ export default function ChatPage() {
     if (!profileId) return;
     getProjects(profileId).then((r) => setProjects(r.projects)).catch(() => {});
     getConversations(profileId).then((r) => setConversations(r.conversations)).catch(() => {});
-    setActiveId(''); setMessages([]);
+    setActiveId(''); setDraftProjectId(null); setMessages([]); setSearch(''); setResults(null);
   }, [profileId]);
 
   useEffect(() => {
@@ -68,6 +67,17 @@ export default function ChatPage() {
     return () => close();
   }, [activeId]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Debounced search (title + message content) via the bridge.
+  useEffect(() => {
+    if (!profileId) return;
+    const q = search.trim();
+    if (!q) { setResults(null); return; }
+    const t = setTimeout(() => {
+      searchConversations(profileId, q).then((r) => setResults(r.conversations)).catch(() => setResults([]));
+    }, 220);
+    return () => clearTimeout(t);
+  }, [search, profileId]);
+
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
   }, [messages, tools, questions]);
@@ -76,7 +86,6 @@ export default function ChatPage() {
     if (profileId) getConversations(profileId).then((r) => setConversations(r.conversations)).catch(() => {});
   }, [profileId]);
 
-  // Insert-or-update a message by id (idempotent).
   function upsert(id: string, patch: Partial<Message> & { role: Message['role']; content: string }) {
     setMessages((m) => {
       const i = m.findIndex((x) => x.id === id);
@@ -91,9 +100,7 @@ export default function ChatPage() {
   function handleEvent(e: BridgeEvent) {
     switch (e.type) {
       case 'sync': setRunning(e.running); setQueued(e.queued); break;
-      case 'user':
-        upsert(e.messageId, { role: 'user', content: e.text + (e.attachments?.length ? `\n\n📎 ${e.attachments.length} file(s)` : '') });
-        break;
+      case 'user': upsert(e.messageId, { role: 'user', content: e.text + (e.attachments?.length ? `\n\n📎 ${e.attachments.length} file(s)` : '') }); break;
       case 'start': setRunning(true); setTools([]); setQuestions(null); break;
       case 'text': upsert(`seg-${e.messageId}`, { role: 'assistant', content: e.text }); break;
       case 'tool': setTools((t) => (t[t.length - 1] === e.name ? t : [...t, e.name])); break;
@@ -105,30 +112,42 @@ export default function ChatPage() {
     }
   }
 
-  async function newConversation(projectId: string) {
-    const r = await createConversation(projectId, profileId, model);
-    setConversations((c) => [r.conversation, ...c]);
-    setActiveId(r.conversation.id); setMessages([]);
+  function startDraft(projectId: string) {
+    setNewOpen(false);
+    setActiveId('');
+    setDraftProjectId(projectId);
+    setMessages([]); setTools([]); setQuestions(null);
   }
 
-  function startNewChat() {
-    const def = projects.find((p) => /general/i.test(p.name)) ?? projects[0];
-    if (def) newConversation(def.id);
+  function openConversation(id: string) {
+    setDraftProjectId(null);
+    setActiveId(id);
   }
 
   async function onPickFiles(files: FileList | null) {
-    if (!files || !activeId) return;
+    if (!files) return;
+    const convId = activeId || 'draft';
     for (const f of Array.from(files)) {
-      try { const path = await uploadFile(activeId, f); setPending((p) => [...p, { name: f.name, path }]); } catch { /* */ }
+      try { const path = await uploadFile(convId, f); setPending((p) => [...p, { name: f.name, path }]); } catch { /* */ }
     }
   }
 
   async function send(promptOverride?: string) {
     const prompt = (promptOverride ?? input).trim();
-    if (!prompt || !activeId) return;
+    if (!prompt) return;
+    let convId = activeId;
+    // Draft → create the conversation only now, on first send.
+    if (!convId && draftProjectId) {
+      const r = await createConversation(draftProjectId, profileId, model);
+      convId = r.conversation.id;
+      setConversations((c) => [r.conversation, ...c]);
+      setDraftProjectId(null);
+      setActiveId(convId);
+    }
+    if (!convId) return;
     const attachments = pending.map((p) => p.path);
     setInput(''); setPending([]);
-    await sendMessage({ conversationId: activeId, prompt, model, attachments }).catch(() => {});
+    await sendMessage({ conversationId: convId, prompt, model, attachments }).catch(() => {});
   }
 
   function submitAnswers(answers: { question: string; answer: string }[]) {
@@ -137,16 +156,16 @@ export default function ChatPage() {
     send(reply);
   }
 
-  const activeConv = conversations.find((c) => c.id === activeId);
+  const projectName = (id: string) => projects.find((p) => p.id === id)?.name ?? '';
+  const list = results ?? conversations;
+  const composing = !!activeId || !!draftProjectId;
   const lastIsUser = messages.length > 0 && messages[messages.length - 1].role === 'user';
   const showSpinner = running && lastIsUser && tools.length === 0;
 
   if (!ready) {
     return (
       <div className="chat-shell" style={{ gridTemplateColumns: '1fr' }}>
-        <div className="chat-empty" style={{ margin: 'auto' }}>
-          <Loader className="chat-spin" size={20} /> Checking access…
-        </div>
+        <div className="chat-empty" style={{ margin: 'auto' }}><Loader className="chat-spin" size={20} /> Checking access…</div>
       </div>
     );
   }
@@ -161,33 +180,46 @@ export default function ChatPage() {
           </select>
           <button title="Enable notifications" className="chat-bell" onClick={() => profileId && enablePush(profileId)}><Bell size={15} /></button>
         </div>
-        <button className="chat-newchat" onClick={startNewChat} disabled={!projects.length}>
-          <Plus size={16} /> New chat
-        </button>
-        <div className="chat-projects">
-          {projects.map((proj) => (
-            <div key={proj.id} className="chat-project">
-              <div className="chat-project-head">
-                <span><Hash size={13} /> {proj.name}{proj.scope === 'shared' && <em> · shared</em>}</span>
-                <button title="New conversation" onClick={() => newConversation(proj.id)}><Plus size={14} /></button>
-              </div>
-              {conversations.filter((c) => c.projectId === proj.id).map((c) => (
-                <button key={c.id} className={`chat-conv ${c.id === activeId ? 'chat-conv-on' : ''}`} onClick={() => setActiveId(c.id)}>{c.title}</button>
+
+        {/* New chat with project picker */}
+        <div className="chat-new">
+          <button className="chat-newchat" onClick={() => setNewOpen((o) => !o)} disabled={!projects.length}>
+            <Plus size={16} /> New chat <ChevronDown size={14} />
+          </button>
+          {newOpen && (
+            <div className="chat-new-menu">
+              {projects.map((p) => (
+                <button key={p.id} onClick={() => startDraft(p.id)}>
+                  {p.name}{p.scope === 'shared' && <em> · shared</em>}
+                </button>
               ))}
             </div>
+          )}
+        </div>
+
+        {/* Search */}
+        <div className="chat-search">
+          <Search size={14} />
+          <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search chats…" />
+        </div>
+
+        {/* Flat conversation list with topic badge */}
+        <div className="chat-convs">
+          {list.length === 0 && <div className="chat-convs-empty">{search ? 'No matches' : 'No conversations yet'}</div>}
+          {list.map((c) => (
+            <button key={c.id} className={`chat-conv ${c.id === activeId ? 'chat-conv-on' : ''}`} onClick={() => openConversation(c.id)}>
+              <span className="chat-conv-title">{c.title}</span>
+              <span className="chat-conv-badge">{projectName(c.projectId)}</span>
+            </button>
           ))}
         </div>
       </aside>
 
       <main className="chat-main">
         <div className="chat-thread" ref={scrollRef}>
-          {!activeId && (
-            <div className="chat-empty">
-              <p>Start a new conversation, or pick one from the sidebar.</p>
-              <button className="chat-newchat chat-newchat-lg" onClick={startNewChat} disabled={!projects.length}>
-                <Plus size={16} /> New chat
-              </button>
-            </div>
+          {!composing && <div className="chat-empty">Start a new chat or pick a conversation.</div>}
+          {composing && messages.length === 0 && (
+            <div className="chat-empty chat-draft-hint">New chat{draftProjectId ? ` in ${projectName(draftProjectId)}` : ''} — type a message to begin.</div>
           )}
           {messages.map((m) => (
             <div key={m.id} className={`chat-msg chat-msg-${m.role}`}>
@@ -199,12 +231,10 @@ export default function ChatPage() {
           {questions && <QuestionPanel questions={questions.items} onSubmit={submitAnswers} />}
         </div>
 
-        {activeId && (
+        {composing && (
           <div className="chat-composer">
             {(running || queued > 1) && (
-              <div className="chat-status">
-                <Loader className="chat-spin" size={12} /> {running ? 'Working…' : ''}{queued > 1 ? ` ${queued - 1} queued` : ''} — keep typing, messages queue
-              </div>
+              <div className="chat-status"><Loader className="chat-spin" size={12} /> {running ? 'Working…' : ''}{queued > 1 ? ` ${queued - 1} queued` : ''} — keep typing, messages queue</div>
             )}
             {pending.length > 0 && <div className="chat-attachments">{pending.map((p, i) => <span key={i}>📎 {p.name}</span>)}</div>}
             {!questions && (
@@ -221,11 +251,8 @@ export default function ChatPage() {
                     <button onClick={() => fileRef.current?.click()} title="Attach image"><Paperclip size={16} /></button>
                     <input ref={fileRef} type="file" accept="image/*" multiple hidden onChange={(e) => onPickFiles(e.target.files)} />
                     <select value={model} onChange={(e) => setModel(e.target.value)}>{MODELS.map((m) => <option key={m} value={m}>{m}</option>)}</select>
-                    {activeConv && <span className="chat-cwd">{activeConv.title}</span>}
                   </div>
-                  <button className="chat-send" onClick={() => send()} disabled={!input.trim()}>
-                    <Send size={16} />
-                  </button>
+                  <button className="chat-send" onClick={() => send()} disabled={!input.trim()}><Send size={16} /></button>
                 </div>
               </>
             )}

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -96,6 +96,11 @@ export default function ChatPage() {
     setActiveId(r.conversation.id); setMessages([]);
   }
 
+  function startNewChat() {
+    const def = projects.find((p) => /general/i.test(p.name)) ?? projects[0];
+    if (def) newConversation(def.id);
+  }
+
   async function onPickFiles(files: FileList | null) {
     if (!files || !activeId) return;
     for (const f of Array.from(files)) {
@@ -131,6 +136,9 @@ export default function ChatPage() {
           </select>
           <button title="Enable notifications" className="chat-bell" onClick={() => profileId && enablePush(profileId)}><Bell size={15} /></button>
         </div>
+        <button className="chat-newchat" onClick={startNewChat} disabled={!projects.length}>
+          <Plus size={16} /> New chat
+        </button>
         <div className="chat-projects">
           {projects.map((proj) => (
             <div key={proj.id} className="chat-project">
@@ -148,7 +156,14 @@ export default function ChatPage() {
 
       <main className="chat-main">
         <div className="chat-thread" ref={scrollRef}>
-          {!activeId && <div className="chat-empty">Pick a project and start a conversation.</div>}
+          {!activeId && (
+            <div className="chat-empty">
+              <p>Start a new conversation, or pick one from the sidebar.</p>
+              <button className="chat-newchat chat-newchat-lg" onClick={startNewChat} disabled={!projects.length}>
+                <Plus size={16} /> New chat
+              </button>
+            </div>
+          )}
           {messages.map((m) => (
             <div key={m.id} className={`chat-msg chat-msg-${m.role}`}>
               {m.role === 'assistant' ? <Markdown>{m.content}</Markdown> : <div className="chat-user-text">{m.content}</div>}

--- a/apps/web/src/components/chat/Markdown.tsx
+++ b/apps/web/src/components/chat/Markdown.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+// Rendered markdown with GFM (tables, strikethrough, task lists, autolinks).
+export function Markdown({ children }: { children: string }) {
+  return (
+    <div className="chat-prose">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: (props) => <a {...props} target="_blank" rel="noopener noreferrer" />,
+          code: ({ className, children, ...rest }) => {
+            const inline = !className;
+            return inline ? (
+              <code className="chat-code-inline" {...rest}>{children}</code>
+            ) : (
+              <code className={className} {...rest}>{children}</code>
+            );
+          },
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/PwaRegister.tsx
+++ b/apps/web/src/components/chat/PwaRegister.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// Registers the service worker so the chat is installable + can receive push.
+export function PwaRegister() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => {});
+    }
+  }, []);
+  return null;
+}

--- a/apps/web/src/components/chat/QuestionPanel.tsx
+++ b/apps/web/src/components/chat/QuestionPanel.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+import type { Question } from '@/lib/chat/api';
+
+// Batched question form: renders ALL questions, collects every answer, and only
+// submits once. Fixes Discord's flow where answering one question started processing.
+export function QuestionPanel({
+  questions, onSubmit,
+}: {
+  questions: Question[];
+  onSubmit: (answers: { question: string; answer: string }[]) => void;
+}) {
+  const [answers, setAnswers] = useState<Record<number, string[]>>({});
+  const [custom, setCustom] = useState<Record<number, string>>({});
+
+  const toggle = (qi: number, label: string, multi: boolean) => {
+    setAnswers((prev) => {
+      const cur = prev[qi] ?? [];
+      if (multi) {
+        return { ...prev, [qi]: cur.includes(label) ? cur.filter((l) => l !== label) : [...cur, label] };
+      }
+      return { ...prev, [qi]: [label] };
+    });
+  };
+
+  const allAnswered = questions.every((_, qi) => (answers[qi]?.length ?? 0) > 0 || custom[qi]?.trim());
+
+  const submit = () => {
+    const payload = questions.map((q, qi) => {
+      const picked = answers[qi] ?? [];
+      const extra = custom[qi]?.trim();
+      const all = extra ? [...picked, extra] : picked;
+      return { question: q.question, answer: all.join(', ') };
+    });
+    onSubmit(payload);
+  };
+
+  return (
+    <div className="chat-questions">
+      <div className="chat-questions-title">A few questions before I continue</div>
+      {questions.map((q, qi) => (
+        <div key={qi} className="chat-question">
+          <div className="chat-question-label">
+            <span className="chat-question-chip">{q.header}</span>
+            {q.question}
+          </div>
+          <div className="chat-question-options">
+            {q.options.map((opt) => {
+              const selected = (answers[qi] ?? []).includes(opt.label);
+              return (
+                <button
+                  key={opt.label}
+                  type="button"
+                  onClick={() => toggle(qi, opt.label, q.multiSelect)}
+                  className={`chat-option ${selected ? 'chat-option-on' : ''}`}
+                >
+                  <span className="chat-option-label">{opt.label}</span>
+                  <span className="chat-option-desc">{opt.description}</span>
+                </button>
+              );
+            })}
+          </div>
+          <input
+            className="chat-question-custom"
+            placeholder="Or type your own…"
+            value={custom[qi] ?? ''}
+            onChange={(e) => setCustom((c) => ({ ...c, [qi]: e.target.value }))}
+          />
+        </div>
+      ))}
+      <button type="button" className="chat-submit-answers" disabled={!allAnswered} onClick={submit}>
+        Submit answers
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/lib/chat/api.ts
+++ b/apps/web/src/lib/chat/api.ts
@@ -83,6 +83,7 @@ export type BridgeEvent =
   | { type: 'tool'; name: string }
   | { type: 'questions'; questions: Question[]; toolUseId: string }
   | { type: 'done'; costUsd?: number; isError?: boolean }
+  | { type: 'title'; conversationId: string; title: string }
   | { type: 'error'; message: string }
   | { type: 'end' }
   | { type: 'idle' };

--- a/apps/web/src/lib/chat/api.ts
+++ b/apps/web/src/lib/chat/api.ts
@@ -73,10 +73,10 @@ export type BridgeEvent =
   | { type: 'sync'; running: boolean; queued: number }
   | { type: 'user'; messageId: string; text: string; attachments: string[]; queued: boolean }
   | { type: 'start'; sessionId: string; model: string }
-  | { type: 'text'; text: string }
+  | { type: 'text'; messageId: string; text: string }
   | { type: 'tool'; name: string }
   | { type: 'questions'; questions: Question[]; toolUseId: string }
-  | { type: 'done'; text: string; costUsd?: number; isError?: boolean }
+  | { type: 'done'; costUsd?: number; isError?: boolean }
   | { type: 'error'; message: string }
   | { type: 'end' }
   | { type: 'idle' };

--- a/apps/web/src/lib/chat/api.ts
+++ b/apps/web/src/lib/chat/api.ts
@@ -41,6 +41,12 @@ export const createConversation = (projectId: string, profileId: string, model?:
     body: JSON.stringify({ projectId, profileId, model }),
   }).then(j);
 
+export const searchConversations = (profileId: string, q: string): Promise<{ conversations: Conversation[] }> =>
+  fetch(`/api/bridge/search?profileId=${profileId}&q=${encodeURIComponent(q)}`).then(j);
+
+export const deleteConversation = (id: string): Promise<{ ok: boolean }> =>
+  fetch(`/api/bridge/conversations/${id}`, { method: 'DELETE' }).then(j);
+
 export const createProject = (p: { name: string; cwd: string; scope?: string; profileId?: string }): Promise<{ project: Project }> =>
   fetch('/api/bridge/projects', {
     method: 'POST', headers: { 'content-type': 'application/json' },

--- a/apps/web/src/lib/chat/api.ts
+++ b/apps/web/src/lib/chat/api.ts
@@ -1,0 +1,98 @@
+// Client API for the chat UI -> /api/bridge proxy -> local claude-bridge.
+
+export type Profile = {
+  id: string; name: string; memoryRoot: string; allowedCwds: string;
+  defaultModel: string; systemPrompt: string | null;
+};
+export type Project = {
+  id: string; name: string; scope: 'private' | 'shared'; profileId: string | null;
+  cwd: string; systemPrompt: string | null; defaultModel: string | null; pinned: number;
+};
+export type Conversation = {
+  id: string; projectId: string; profileId: string; sessionId: string | null;
+  title: string; model: string | null; createdAt: number; updatedAt: number;
+};
+export type Message = {
+  id: string; conversationId: string; role: 'user' | 'assistant';
+  content: string; attachments: string | null; createdAt: number;
+};
+export type Question = {
+  question: string; header: string; multiSelect: boolean;
+  options: { label: string; description: string }[];
+};
+
+const j = async (r: Response) => {
+  if (!r.ok) throw new Error((await r.json().catch(() => ({})))?.error ?? r.statusText);
+  return r.json();
+};
+
+export const getProfiles = (): Promise<{ profiles: Profile[] }> =>
+  fetch('/api/bridge/profiles').then(j);
+export const getProjects = (profileId: string): Promise<{ projects: Project[] }> =>
+  fetch(`/api/bridge/projects?profileId=${profileId}`).then(j);
+export const getConversations = (profileId: string): Promise<{ conversations: Conversation[] }> =>
+  fetch(`/api/bridge/conversations?profileId=${profileId}`).then(j);
+export const getMessages = (conversationId: string): Promise<{ messages: Message[] }> =>
+  fetch(`/api/bridge/conversations/${conversationId}/messages`).then(j);
+
+export const createConversation = (projectId: string, profileId: string, model?: string): Promise<{ conversation: Conversation }> =>
+  fetch('/api/bridge/conversations', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ projectId, profileId, model }),
+  }).then(j);
+
+export const createProject = (p: { name: string; cwd: string; scope?: string; profileId?: string }): Promise<{ project: Project }> =>
+  fetch('/api/bridge/projects', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(p),
+  }).then(j);
+
+export async function uploadFile(conversationId: string, file: File): Promise<string> {
+  const dataBase64 = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve((reader.result as string).split(',')[1]);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+  const res = await fetch('/api/bridge/upload', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ conversationId, filename: file.name, dataBase64 }),
+  }).then(j);
+  return res.path as string;
+}
+
+// Fire-and-forget: enqueue a message. The run is owned by the bridge; observe via
+// the conversation stream. Safe to call while a turn is in flight (it queues).
+export const sendMessage = (body: { conversationId: string; prompt: string; model?: string; attachments?: string[] }): Promise<{ ok: boolean; queued: number }> =>
+  fetch('/api/bridge/chat', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }).then(j);
+
+export type BridgeEvent =
+  | { type: 'sync'; running: boolean; queued: number }
+  | { type: 'user'; messageId: string; text: string; attachments: string[]; queued: boolean }
+  | { type: 'start'; sessionId: string; model: string }
+  | { type: 'text'; text: string }
+  | { type: 'tool'; name: string }
+  | { type: 'questions'; questions: Question[]; toolUseId: string }
+  | { type: 'done'; text: string; costUsd?: number; isError?: boolean }
+  | { type: 'error'; message: string }
+  | { type: 'end' }
+  | { type: 'idle' };
+
+// Opens a re-attachable SSE stream for a conversation (cookie-authed via proxy).
+// Auto-reconnects (native EventSource). Returns a close fn.
+export function openStream(conversationId: string, onEvent: (e: BridgeEvent) => void): () => void {
+  const es = new EventSource(`/api/bridge/conversations/${conversationId}/stream`);
+  es.onmessage = (m) => { try { onEvent(JSON.parse(m.data)); } catch { /* ignore */ } };
+  return () => es.close();
+}
+
+// ---- Push ----
+export const getVapidKey = (): Promise<{ key: string | null }> => fetch('/api/bridge/push/vapid').then(j);
+export const subscribePush = (profileId: string, subscription: PushSubscriptionJSON): Promise<{ ok: boolean }> =>
+  fetch('/api/bridge/push/subscribe', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ profileId, subscription }),
+  }).then(j);

--- a/apps/web/src/lib/chat/push-client.ts
+++ b/apps/web/src/lib/chat/push-client.ts
@@ -1,0 +1,35 @@
+import { getVapidKey, subscribePush } from './api';
+
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+  const b64 = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(b64);
+  return Uint8Array.from([...raw].map((c) => c.charCodeAt(0)));
+}
+
+// Registers the SW, requests permission, subscribes to push, and stores the
+// subscription on the bridge (keyed by profile). On iOS this only works once the
+// PWA is installed to the home screen and served over HTTPS.
+export async function enablePush(profileId: string): Promise<void> {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+    alert('Push not supported here. On iPhone: add to Home Screen first, then enable.');
+    return;
+  }
+  const perm = await Notification.requestPermission();
+  if (perm !== 'granted') { alert('Notifications were not allowed.'); return; }
+
+  const reg = await navigator.serviceWorker.register('/sw.js');
+  await navigator.serviceWorker.ready;
+
+  const { key } = await getVapidKey();
+  if (!key) {
+    alert('Server push not configured yet (needs VAPID keys + a public HTTPS origin via Funnel).');
+    return;
+  }
+  const sub = await reg.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(key) as BufferSource,
+  });
+  await subscribePush(profileId, sub.toJSON() as PushSubscriptionJSON);
+  alert('Notifications enabled.');
+}


### PR DESCRIPTION
## What
Adds a Claude-app-like chat interface at **/chat** on evanm.xyz, backed by a local Claude Code agent (`~/Projects/claude-bridge`) so it has full access to the Obsidian vault, skills, hooks, and MCP servers. First step toward replacing Discord (marv) as the primary interface.

## Architecture
Browser → `/chat` (gated by existing login) → `/api/bridge/[...path]` proxy (holds bridge token server-side) → **claude-bridge** on the Mac → `claude --output-format stream-json`.

- **POC transport:** local (`BRIDGE_URL=http://127.0.0.1:8787`). 
- **Remote:** Tailscale Funnel → later tailnet-private proxy (see `claude-bridge/PLAN.md`).

## Included
- Streaming SSE chat, rendered **Markdown + GFM** (tables, lists, code)
- **Profile switcher** — per-user memory isolation (e.g. spouse gets her own vault root + her own chats); shared projects supported
- **Project / conversation sidebar** (pinned, Discord-channel-like) with session resume
- **Model selector** (sonnet/opus/haiku) with per-conversation default
- **Image upload** (→ saved on Mac, path passed to Claude's Read)
- **Batched question panel** — renders all AskUserQuestion items and submits answers together (fixes Discord's "answered one, it started processing" bug)
- No character limit; voice-to-text works via native dictation

## New env (web)
- `BRIDGE_URL` — claude-bridge base URL
- `BRIDGE_TOKEN` — shared bearer token for the bridge

## Testing
Verified locally end-to-end with Playwright: profile/projects/conversations load through the proxy, new conversation streams a response, markdown table renders, title auto-derives. Backend loop (create → chat → resume → persist) verified via curl.

## Notes / not yet done
- Bridge must be running; remote access needs Tailscale Funnel enabled (blocked on a 1-time admin-console step — tracked in `claude-bridge/PLAN.md`).
- Profile creation UI, shared-memory root seeding, and design polish are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)